### PR TITLE
Temporarily disable image pruner

### DIFF
--- a/config/registry_image_pruner/cronjob.yaml
+++ b/config/registry_image_pruner/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
             command:
               - /bin/bash
               - '-c'
-              - python /image-pruner/prune_images.py --namespace $(NAMESPACE)
+              - echo 'The pruner is temporarily disabled, see https://github.com/konflux-ci/image-controller/pull/115'
             volumeMounts:
               - name: image-pruner-volume
                 mountPath: /image-pruner


### PR DESCRIPTION
[STONEBLD-2466](https://issues.redhat.com//browse/STONEBLD-2466)

The pruner may improperly delete the 'sha256-${digest}.*' attachments for images that still exists.

The pruner is not supposed to delete these attachments if the 'sha256:${digest}' image exists. However, it only takes into account tagged images. Platform-specific manifests do not have to be tagged, it is enough if they are part of a multi-platform image index.

Disable the pruner until the issue is fixed properly.