### PR TITLE
Do not delete sig/att/sbom if subject image exists

### DIFF
--- a/config/registry_image_pruner/cronjob.yaml
+++ b/config/registry_image_pruner/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
             command:
               - /bin/bash
               - '-c'
-              - echo 'The pruner is temporarily disabled, see https://github.com/konflux-ci/image-controller/pull/115'
+              - python /image-pruner/prune_images.py --namespace $(NAMESPACE)
             volumeMounts:
               - name: image-pruner-volume
                 mountPath: /image-pruner


### PR DESCRIPTION
when getting all tags in registry we are listing only active tags, if tag was removed for the image, image still will be in registry if it is part of image index

if manifest digest isn't present in any of active tags, try query also manifest digest to verify its presence

[STONEBLD-2466](https://issues.redhat.com//browse/STONEBLD-2466)