### PR TITLE
Quay notification add, update and delete support for ImageRepository

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -218,6 +218,15 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	if err = r.HandleNotifications(ctx, imageRepository); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.Client.Status().Update(ctx, imageRepository); err != nil {
+		log.Error(err, "failed to update image repository status")
+		return ctrl.Result{}, err
+	}
+
 	// we are adding to map only for new provision, not for some partial actions,
 	// so report time only if time was recorded
 	provisionTime, timeRecorded := metrics.RepositoryTimesForMetrics[repositoryIdForMetrics]
@@ -228,51 +237,6 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	delete(metrics.RepositoryTimesForMetrics, repositoryIdForMetrics)
 
 	return ctrl.Result{}, nil
-}
-
-func (r *ImageRepositoryReconciler) AddNotifications(ctx context.Context, imageRepository *imagerepositoryv1alpha1.ImageRepository) ([]imagerepositoryv1alpha1.NotificationStatus, error) {
-	log := ctrllog.FromContext(ctx).WithName("ConfigureNotifications")
-
-	if imageRepository.Spec.Notifications == nil {
-		// No notifications to configure
-		return nil, nil
-	}
-
-	log.Info("Configuring notifications")
-	notificationStatus := []imagerepositoryv1alpha1.NotificationStatus{}
-
-	for _, notification := range imageRepository.Spec.Notifications {
-		log.Info("Creating notification in Quay", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method)
-		quayNotification, err := r.QuayClient.CreateNotification(
-			r.QuayOrganization,
-			imageRepository.Spec.Image.Name,
-			quay.Notification{
-				Title:  notification.Title,
-				Event:  string(notification.Event),
-				Method: string(notification.Method),
-				Config: quay.NotificationConfig{
-					Url: notification.Config.Url,
-				},
-				EventConfig: quay.NotificationEventConfig{},
-			})
-		if err != nil {
-			log.Error(err, "failed to create notification", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method)
-			return nil, err
-		}
-		notificationStatus = append(
-			notificationStatus,
-			imagerepositoryv1alpha1.NotificationStatus{
-				UUID:  quayNotification.UUID,
-				Title: notification.Title,
-			})
-
-		log.Info("Notification added",
-			"Title", notification.Title,
-			"Event", notification.Event,
-			"Method", notification.Method,
-			"QuayNotification", quayNotification)
-	}
-	return notificationStatus, nil
 }
 
 // ProvisionImageRepository creates image repository, robot account(s) and secret(s) to access the image repository.
@@ -364,7 +328,7 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 	}
 
 	var notificationStatus []imagerepositoryv1alpha1.NotificationStatus
-	if notificationStatus, err = r.AddNotifications(ctx, imageRepository); err != nil {
+	if notificationStatus, err = r.SetNotifications(ctx, imageRepository); err != nil {
 		return err
 	}
 
@@ -683,4 +647,15 @@ func getRandomString(length int) string {
 		panic("Failed to read from random generator")
 	}
 	return hex.EncodeToString(bytes)[0:length]
+}
+
+func (r *ImageRepositoryReconciler) UpdateImageRepositoryStatusMessage(ctx context.Context, imageRepository *imagerepositoryv1alpha1.ImageRepository, statusMessage string) error {
+	log := ctrllog.FromContext(ctx)
+	imageRepository.Status.Message = statusMessage
+	if err := r.Client.Status().Update(ctx, imageRepository); err != nil {
+		log.Error(err, "failed to update image repository status")
+		return err
+	}
+
+	return nil
 }

--- a/controllers/imagerepository_notifications.go
+++ b/controllers/imagerepository_notifications.go
@@ -1,0 +1,225 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+
+	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
+	"github.com/konflux-ci/image-controller/pkg/quay"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func (r *ImageRepositoryReconciler) AddNotification(notification imagerepositoryv1alpha1.Notifications, imageRepository *imagerepositoryv1alpha1.ImageRepository) (imagerepositoryv1alpha1.NotificationStatus, error) {
+	notificationStatus := imagerepositoryv1alpha1.NotificationStatus{}
+	quayNotification, err := r.QuayClient.CreateNotification(
+		r.QuayOrganization,
+		imageRepository.Spec.Image.Name,
+		quay.Notification{
+			Title:  notification.Title,
+			Event:  string(notification.Event),
+			Method: string(notification.Method),
+			Config: quay.NotificationConfig{
+				Url: notification.Config.Url,
+			},
+			EventConfig: quay.NotificationEventConfig{},
+		})
+
+	if err != nil {
+		return notificationStatus, err
+	}
+	return imagerepositoryv1alpha1.NotificationStatus{
+		UUID:  quayNotification.UUID,
+		Title: notification.Title,
+	}, nil
+}
+
+func (r *ImageRepositoryReconciler) checkNotificationChangesExists(imageRepository *imagerepositoryv1alpha1.ImageRepository, allNotifications []quay.Notification) bool {
+	if len(allNotifications) != len(imageRepository.Spec.Notifications) {
+		return true
+	}
+	for _, quayNotification := range allNotifications {
+		existsAndHasntChanged := false
+		for _, notification := range imageRepository.Spec.Notifications {
+			if quayNotification.Title == notification.Title && !isNotificationChanged(notification, quayNotification) {
+				existsAndHasntChanged = true
+				break
+			}
+		}
+		if !existsAndHasntChanged {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *ImageRepositoryReconciler) HandleNotifications(ctx context.Context, imageRepository *imagerepositoryv1alpha1.ImageRepository) error {
+	log := ctrllog.FromContext(ctx).WithName("HandleNotifications")
+
+	if imageRepository.Status.Notifications == nil && imageRepository.Spec.Notifications == nil {
+		// No status notifications to check
+		return nil
+	}
+	allNotifications, err := r.QuayClient.GetNotifications(r.QuayOrganization, imageRepository.Spec.Image.Name)
+	if err != nil {
+		return r.handleError(ctx, imageRepository, err, "Couldn't retrieve all Quay notifications")
+	}
+	if !r.checkNotificationChangesExists(imageRepository, allNotifications) {
+		return nil
+	}
+	for index := 0; index < len(imageRepository.Status.Notifications); index++ {
+		statusNotification := &imageRepository.Status.Notifications[index] // This way we can update the UUID if notification gets updated
+		existsInSpec := false
+		for _, notification := range imageRepository.Spec.Notifications {
+			if notification.Title == statusNotification.Title {
+				existsInSpec = true
+				quayNotification, err := r.notificationExistsInQuayByUUID(statusNotification.UUID, imageRepository)
+				if err != nil {
+					return r.handleError(ctx, imageRepository, err, "Couldn't retrieve all Quay notifications")
+				}
+				if isNotificationChanged(notification, quayNotification) {
+					// Updated item in Spec.Notifications: update notification in Quay
+					log.Info("Updating notification in Quay", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method, "UUID", quayNotification.UUID)
+					updatedNotification, err := r.QuayClient.UpdateNotification(
+						r.QuayOrganization,
+						imageRepository.Spec.Image.Name,
+						statusNotification.UUID,
+						quay.Notification{
+							Title:  notification.Title,
+							Event:  string(notification.Event),
+							Method: string(notification.Method),
+							Config: quay.NotificationConfig{
+								Url: notification.Config.Url,
+							},
+							EventConfig: quay.NotificationEventConfig{},
+						})
+					if err != nil {
+						log.Error(err, "failed to update notification", "Title", statusNotification.Title, "UUID", statusNotification.UUID)
+						return r.handleError(ctx, imageRepository, err, "Error while updating notification ("+notification.Title+")")
+					}
+					statusNotification.UUID = updatedNotification.UUID
+					statusNotification.Title = updatedNotification.Title
+					break
+				}
+			} else {
+				exists, err := r.notificationExistsInQuayByTitle(notification.Title, imageRepository)
+				if err != nil {
+					return r.handleError(ctx, imageRepository, err, "Couldn't retrieve all Quay notifications")
+				}
+				if !exists {
+					// New item in Spec.Notifications: add notification to Quay and Status.Notifications
+					log.Info("Adding new notification to Quay", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method)
+					resStatusNotification, err := r.AddNotification(notification, imageRepository)
+					if err != nil {
+						log.Error(err, "failed to add notification", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method)
+						return r.handleError(ctx, imageRepository, err, "Error while adding a notification ("+notification.Title+") to Quay")
+					}
+					existsInStatus := false
+					for _, statusNotificationAux := range imageRepository.Status.Notifications {
+						if resStatusNotification.UUID == statusNotificationAux.UUID {
+							existsInStatus = true
+							break
+						}
+					}
+					if !existsInStatus {
+						imageRepository.Status.Notifications = append(imageRepository.Status.Notifications, resStatusNotification)
+					}
+				}
+			}
+		}
+		if !existsInSpec {
+			// Deleted item from Spec.Notifications: delete notification from Quay and Status.Notifications
+			log.Info("Deleting notification in Quay", "Title", statusNotification.Title, "UUID", statusNotification.UUID)
+			_, err := r.QuayClient.DeleteNotification(
+				r.QuayOrganization,
+				imageRepository.Spec.Image.Name,
+				statusNotification.UUID)
+			if err != nil {
+				log.Error(err, "failed to delete notification", "Title", statusNotification.Title, "UUID", statusNotification.UUID)
+				return r.handleError(ctx, imageRepository, err, "Error while deleting a notification ("+statusNotification.Title+") to Quay")
+			}
+			// Remove notification from CR status
+			imageRepository.Status.Notifications = append(imageRepository.Status.Notifications[:index], imageRepository.Status.Notifications[index+1:]...)
+			index--
+		}
+	}
+
+	return nil
+}
+
+// This function adds all Spec.Notifications to Quay and overwrites all existing notifications in ImageRepository Status
+func (r *ImageRepositoryReconciler) SetNotifications(ctx context.Context, imageRepository *imagerepositoryv1alpha1.ImageRepository) ([]imagerepositoryv1alpha1.NotificationStatus, error) {
+	log := ctrllog.FromContext(ctx).WithName("ConfigureNotifications")
+
+	if imageRepository.Spec.Notifications == nil {
+		// No notifications to configure
+		return nil, nil
+	}
+
+	log.Info("Adding notifications")
+	notificationStatus := []imagerepositoryv1alpha1.NotificationStatus{}
+
+	for _, notification := range imageRepository.Spec.Notifications {
+		log.Info("Creating notification in Quay", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method)
+		notificationStatusRes, err := r.AddNotification(notification, imageRepository)
+		if err != nil {
+			log.Error(err, "failed to create notification", "Title", notification.Title, "Event", notification.Event, "Method", notification.Method)
+			resErr := r.handleError(ctx, imageRepository, err, "Error while adding a notification ("+notification.Title+") to Quay")
+			return nil, resErr
+		}
+		notificationStatus = append(notificationStatus, notificationStatusRes)
+		log.Info("Notification added",
+			"Title", notification.Title,
+			"Event", notification.Event,
+			"Method", notification.Method,
+			"QuayNotification", notificationStatusRes)
+	}
+	return notificationStatus, nil
+}
+
+func (r *ImageRepositoryReconciler) notificationExistsInQuayByUUID(UUID string, imageRepository *imagerepositoryv1alpha1.ImageRepository) (quay.Notification, error) {
+	notification := quay.Notification{}
+	allNotifications, err := r.QuayClient.GetNotifications(r.QuayOrganization, imageRepository.Spec.Image.Name)
+	if err != nil {
+		return notification, nil
+	}
+	for _, quayNotification := range allNotifications {
+		if quayNotification.UUID == UUID {
+			notification = quayNotification
+			break
+		}
+	}
+
+	return notification, nil
+}
+
+func (r *ImageRepositoryReconciler) notificationExistsInQuayByTitle(title string, imageRepository *imagerepositoryv1alpha1.ImageRepository) (bool, error) {
+	exists := false
+	allNotifications, err := r.QuayClient.GetNotifications(r.QuayOrganization, imageRepository.Spec.Image.Name)
+	if err != nil {
+		return exists, err
+	}
+	for _, quayNotification := range allNotifications {
+		if quayNotification.Title == title {
+			exists = true
+			break
+		}
+	}
+
+	return exists, nil
+}
+
+func isNotificationChanged(notification imagerepositoryv1alpha1.Notifications, quayNotification quay.Notification) bool {
+	return quayNotification.UUID != "" && (quayNotification.Title != notification.Title || quayNotification.Event != string(notification.Event) || quayNotification.Method != string(notification.Method) || quayNotification.Config.Url != notification.Config.Url)
+}
+
+func (r *ImageRepositoryReconciler) handleError(ctx context.Context, imageRepository *imagerepositoryv1alpha1.ImageRepository, err error, errorStatusMessage string) error {
+	if strings.Contains(err.Error(), "400") || strings.Contains(err.Error(), "404") {
+		if err = r.UpdateImageRepositoryStatusMessage(ctx, imageRepository, errorStatusMessage); err != nil {
+			return err
+		}
+		return nil
+	} else {
+		return err
+	}
+}

--- a/pkg/quay/test_quay_client.go
+++ b/pkg/quay/test_quay_client.go
@@ -40,6 +40,8 @@ var (
 	RegenerateRobotAccountTokenFunc               func(organization string, robotName string) (*RobotAccount, error)
 	GetNotificationsFunc                          func(organization, repository string) ([]Notification, error)
 	CreateNotificationFunc                        func(organization, repository string, notification Notification) (*Notification, error)
+	UpdateNotificationFunc                        func(organization, repository string, notificationUuid string, notification Notification) (*Notification, error)
+	DeleteNotificationFunc                        func(organization, repository string, notificationUuid string) (bool, error)
 )
 
 func ResetTestQuayClient() {
@@ -55,7 +57,12 @@ func ResetTestQuayClient() {
 	CreateNotificationFunc = func(organization, repository string, notification Notification) (*Notification, error) {
 		return &Notification{}, nil
 	}
-
+	UpdateNotificationFunc = func(organization, repository string, notificationUuid string, notification Notification) (*Notification, error) {
+		return &Notification{}, nil
+	}
+	DeleteNotificationFunc = func(organization, repository string, notificationUuid string) (bool, error) {
+		return true, nil
+	}
 }
 
 func ResetTestQuayClientToFails() {
@@ -101,13 +108,23 @@ func ResetTestQuayClientToFails() {
 	}
 	GetNotificationsFunc = func(organization, repository string) ([]Notification, error) {
 		defer GinkgoRecover()
-		Fail("RegenerateRobotAccountToken invoked")
+		Fail("GetNotificationsFunc invoked")
 		return nil, nil
 	}
 	CreateNotificationFunc = func(organization, repository string, notification Notification) (*Notification, error) {
 		defer GinkgoRecover()
 		Fail("CreateNotification invoked")
 		return nil, nil
+	}
+	UpdateNotificationFunc = func(organization, repository string, notificationUuid string, notification Notification) (*Notification, error) {
+		defer GinkgoRecover()
+		Fail("UpdateNotification invoked")
+		return nil, nil
+	}
+	DeleteNotificationFunc = func(organization, repository string, notificationUuid string) (bool, error) {
+		defer GinkgoRecover()
+		Fail("DeleteNotification invoked")
+		return true, nil
 	}
 }
 
@@ -150,7 +167,12 @@ func (TestQuayClient) GetTagsFromPage(organization string, repository string, pa
 func (TestQuayClient) GetNotifications(organization string, repository string) ([]Notification, error) {
 	return GetNotificationsFunc(organization, repository)
 }
-
 func (TestQuayClient) CreateNotification(organization, repository string, notification Notification) (*Notification, error) {
 	return CreateNotificationFunc(organization, repository, notification)
+}
+func (TestQuayClient) DeleteNotification(organization, repository string, notificationUuid string) (bool, error) {
+	return DeleteNotificationFunc(organization, repository, notificationUuid)
+}
+func (TestQuayClient) UpdateNotification(organization, repository string, notificationUuid string, notification Notification) (*Notification, error) {
+	return UpdateNotificationFunc(organization, repository, notificationUuid, notification)
 }


### PR DESCRIPTION
### Description
Extends the controller to be able to react to CR updates and handle the notifications accordingly.
It allows to modify existing CR specification by adding new notifications, modifying existing ones and deleting them. The controller will react to those changes and reflect them accordingly in Quay as well as in the CR status.

### How has this been tested?
Quay's _UpdateNotification_ and _DeleteNotification_ tested on a mock personal Quay repository using the _quay_test.go_ suite.
Whole functionality tested by deploying the operator to an Openshift cluster and using a test Quay organization to play with ImageRepository's notifications by testing all the functional workflows.

---
This PR is a continuation of this one: https://github.com/konflux-ci/image-controller/pull/112
JIRA: [ISV-4914](https://issues.redhat.com/browse/ISV-4914)
