### PR TITLE
when image in imagerepository Spec.Image.Name is already specified, d…

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -313,7 +313,10 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 			imageRepositoryName = imageRepository.Namespace + "/" + imageRepository.Name
 		}
 	} else {
-		imageRepositoryName = imageRepository.Namespace + "/" + imageRepository.Spec.Image.Name
+		imageRepositoryName = strings.TrimPrefix(imageRepository.Spec.Image.Name, "/")
+		if !strings.HasPrefix(imageRepositoryName, imageRepository.Namespace+"/") {
+			imageRepositoryName = imageRepository.Namespace + "/" + imageRepositoryName
+		}
 	}
 	imageRepository.Spec.Image.Name = imageRepositoryName
 


### PR DESCRIPTION
…on't

add namespace if it is already there

[STONEBLD-2530](https://issues.redhat.com//browse/STONEBLD-2530)