### PR TITLE
Allow simultaneous creation of Component and ImageRepository

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -268,14 +268,12 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 		componentKey := types.NamespacedName{Namespace: imageRepository.Namespace, Name: componentName}
 		if err := r.Client.Get(ctx, componentKey, component); err != nil {
 			if errors.IsNotFound(err) {
-				imageRepository.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
 				imageRepository.Status.Message = fmt.Sprintf("Component '%s' does not exist", componentName)
 				if err := r.Client.Status().Update(ctx, imageRepository); err != nil {
 					log.Error(err, "failed to update imageRepository status", l.Action, l.ActionUpdate)
 					return err
 				}
 				log.Info("attempt to create image repository related to non existing component", "Component", componentName)
-				return nil
 			}
 			log.Error(err, "failed to get component", "ComponentName", componentName, l.Action, l.ActionView)
 			return err

--- a/controllers/imagerepository_controller_test.go
+++ b/controllers/imagerepository_controller_test.go
@@ -1175,10 +1175,10 @@ var _ = Describe("Image repository controller", func() {
 			})
 			defer deleteImageRepository(resourceKey)
 
+			errorMessage := fmt.Sprintf("Component '%s' does not exist", defaultComponentName)
 			Eventually(func() bool {
 				imageRepository := getImageRepository(resourceKey)
-				return imageRepository.Status.State == imagerepositoryv1alpha1.ImageRepositoryStateFailed &&
-					imageRepository.Status.Message != ""
+				return imageRepository.Status.Message == errorMessage
 			}, timeout, interval).Should(BeTrue())
 		})
 


### PR DESCRIPTION
if component doesn't exist yet while image-controller trying to get it, fail but don't set state failed, so it acts as transient error and retries

[STONEBLD-2619](https://issues.redhat.com//browse/STONEBLD-2619)