### PR TITLE
Expose container port for probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,10 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 8081
+          name: probes
+          protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
kube-linter reports errors for this missing exposed container port.