### PR TITLE
Prevent sequential underscores in quay robot account name

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -850,7 +850,7 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 func generateQuayRobotAccountName(imageRepositoryName string, isPullOnly bool) string {
 	// Robot account name must match ^[a-z][a-z0-9_]{1,254}$
 
-	imageNamePrefix := imageRepositoryName
+	imageNamePrefix := removeDuplicateUnderscores(imageRepositoryName)
 	if len(imageNamePrefix) > 220 {
 		imageNamePrefix = imageNamePrefix[:220]
 	}
@@ -865,6 +865,26 @@ func generateQuayRobotAccountName(imageRepositoryName string, isPullOnly bool) s
 		robotAccountName += "_pull"
 	}
 	return robotAccountName
+}
+
+// removeDuplicateUnderscores replaces sequence of underscores with only one.
+// Example: ab__cd___e => ab_cd_e
+func removeDuplicateUnderscores(s string) string {
+	var result strings.Builder
+
+	runes := []rune(s)
+	if len(runes) > 0 {
+		result.WriteRune(runes[0])
+	}
+	for i := 1; i < len(runes); i++ {
+		char := runes[i]
+		prevChar := runes[i-1]
+		if char != '_' || prevChar != '_' {
+			result.WriteRune(char)
+		}
+	}
+
+	return result.String()
 }
 
 func getSecretName(imageRepository *imagerepositoryv1alpha1.ImageRepository, isPullOnly bool) string {

--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -870,21 +871,7 @@ func generateQuayRobotAccountName(imageRepositoryName string, isPullOnly bool) s
 // removeDuplicateUnderscores replaces sequence of underscores with only one.
 // Example: ab__cd___e => ab_cd_e
 func removeDuplicateUnderscores(s string) string {
-	var result strings.Builder
-
-	runes := []rune(s)
-	if len(runes) > 0 {
-		result.WriteRune(runes[0])
-	}
-	for i := 1; i < len(runes); i++ {
-		char := runes[i]
-		prevChar := runes[i-1]
-		if char != '_' || prevChar != '_' {
-			result.WriteRune(char)
-		}
-	}
-
-	return result.String()
+	return regexp.MustCompile("_+").ReplaceAllString(s, "_")
 }
 
 func getSecretName(imageRepository *imagerepositoryv1alpha1.ImageRepository, isPullOnly bool) string {

--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -851,7 +851,7 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 func generateQuayRobotAccountName(imageRepositoryName string, isPullOnly bool) string {
 	// Robot account name must match ^[a-z][a-z0-9_]{1,254}$
 
-	imageNamePrefix := removeDuplicateUnderscores(imageRepositoryName)
+	imageNamePrefix := imageRepositoryName
 	if len(imageNamePrefix) > 220 {
 		imageNamePrefix = imageNamePrefix[:220]
 	}
@@ -865,6 +865,7 @@ func generateQuayRobotAccountName(imageRepositoryName string, isPullOnly bool) s
 	if isPullOnly {
 		robotAccountName += "_pull"
 	}
+	robotAccountName = removeDuplicateUnderscores(robotAccountName)
 	return robotAccountName
 }
 

--- a/controllers/imagerepository_controller_unit_test.go
+++ b/controllers/imagerepository_controller_unit_test.go
@@ -64,6 +64,12 @@ func TestGenerateQuayRobotAccountName(t *testing.T) {
 			isPull:                         false,
 			expectedRobotAccountNamePrefix: "my_app_tenant_component_name",
 		},
+		{
+			name:                           "Should prevent multiple underscores in Quay robot account name cause be other symbols replacement",
+			imageRepositoryName:            "my_._image_/_repository_-_name_",
+			isPull:                         true,
+			expectedRobotAccountNamePrefix: "my_image_repository_name",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/controllers/imagerepository_controller_unit_test.go
+++ b/controllers/imagerepository_controller_unit_test.go
@@ -58,6 +58,12 @@ func TestGenerateQuayRobotAccountName(t *testing.T) {
 			isPull:                         true,
 			expectedRobotAccountNamePrefix: expectedRobotAccountLongPrefix,
 		},
+		{
+			name:                           "Should prevent multiple underscores in Quay robot account name",
+			imageRepositoryName:            "my__app_tenant_component____name",
+			isPull:                         false,
+			expectedRobotAccountNamePrefix: "my_app_tenant_component_name",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -74,6 +80,55 @@ func TestGenerateQuayRobotAccountName(t *testing.T) {
 				if !strings.HasSuffix(robotAccountName, "_pull") {
 					t.Error("Expecting '_pull' suffix for pull robot account name")
 				}
+			}
+		})
+	}
+}
+
+func TestRemoveDuplicateUnderscores(t *testing.T) {
+	testCases := []struct {
+		name     string
+		arg      string
+		expected string
+	}{
+		{
+			name:     "Should not modify string without repeating underscores",
+			arg:      "my_test_string",
+			expected: "my_test_string",
+		},
+		{
+			name:     "Should handle double underscores",
+			arg:      "my_test__string",
+			expected: "my_test_string",
+		},
+		{
+			name:     "Should handle multiple underscores",
+			arg:      "my_test____________string",
+			expected: "my_test_string",
+		},
+		{
+			name:     "Should handle underscores in many places",
+			arg:      "my____test__string",
+			expected: "my_test_string",
+		},
+		{
+			name:     "Should handle underscores at the beginning and end",
+			arg:      "__my_test__string__",
+			expected: "_my_test_string_",
+		},
+		{
+			name:     "Should handle empty string",
+			arg:      "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := removeDuplicateUnderscores(tc.arg)
+
+			if got != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, got)
 			}
 		})
 	}


### PR DESCRIPTION
When namespace has sequential `-` in its name, it converted to sequential `_` in quay robot account name which is not allowed and image repository provision fails. This PR prevents such error by removing duplicate `_` from robot account name.