### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+*   @konflux-ci/build-maintainers

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,0 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
-approvers:
-- mmorhun
-- psturc
-
-reviewers:
-- mmorhun
-- psturc


### PR DESCRIPTION
We need CODEOWNERS to assign reviewers automatically.