### PR TITLE
renovate: follow the 1.x tag of go-toolset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/go-toolset"
+      ],
+      "allowedVersions": [
+        "<2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The go-toolset image [1] recently started adding the version of the
underlying RHEL OS as a floating tag. The image now uses two versioning
schemes:

- based on RHEL version (latest is 9.5)
- based on Go version (latest is 1.22.9)

The Go version is much more relevant than the RHEL version, so make
Renovate follow the Go version tag.

[1]: https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
