### PR TITLE
Support skip the deletion of repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ After any successful operation, `status.message` is cleared.
 
 ---
 
+### Skip repository deletion
+
+By default, if the ImageRepository resource is deleted, the repository it created
+in Quay will get deleted as well.
+
+In order to skip the deletion of the repository in Quay, the `image-controller.appstudio.redhat.com/skip-repository-deletion` annotation should be set to "true".
+
 ## AppStudio Component image repository
 
 ### Image repository for Component builds


### PR DESCRIPTION
In order to support migration of users between clusters while preserving their repositories in Quay, support skipping the deletion of the repository in Quay by setting an annotation on the image repository resource.