### PR TITLE
new service account model

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In case your quay.io organization has free plan that does not allow setting repo
 
 ### Credentials rotation
 
-It's possible to request robot account token rotation by adding:
+It's possible to request robot account token rotation by adding (it will also re-create secret if it doesn't exist):
 ```yaml
 ...
 spec:
@@ -120,7 +120,6 @@ After token rotation, the `spec.credentials.regenerate-token` section will be de
 It will link secret to service account if link is missing.
 It will remove duplicate links of secret in service account.
 It will remove secret from imagePullSecrets in service account.
-It will unlink secret from service account, if secret doesn't exist (you can recreate secret using 'regenerate-token').
 It's possible to request verification and fixing of secrets linking to service account by adding:
 ```yaml
 ...

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -214,6 +214,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.ApplicationPullServiceAccountCreator{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Application")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,10 +30,19 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - create
   - get
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - appstudio.redhat.com

--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
+	l "github.com/konflux-ci/image-controller/pkg/logs"
+	appstudioredhatcomv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+)
+
+// ApplicationPullServiceAccountCreator reconciles a Application object
+type ApplicationPullServiceAccountCreator struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ApplicationPullServiceAccountCreator) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appstudioredhatcomv1alpha1.Application{}).
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+
+func (r *ApplicationPullServiceAccountCreator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx).WithName("Application")
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	// fetch the application instance
+	application := &appstudioredhatcomv1alpha1.Application{}
+	err := r.Client.Get(ctx, req.NamespacedName, application)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// The object is deleted, nothing to do
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "failed to get application", l.Action, l.ActionView)
+		return ctrl.Result{}, err
+	}
+
+	// do nothing when application is to be deleted
+	if !application.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	// fetch application SA
+	applicationSaName := getApplicationSaName(application.Name)
+	applicationServiceAccount := &corev1.ServiceAccount{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: applicationSaName, Namespace: application.Namespace}, applicationServiceAccount)
+	if err == nil {
+		// service account already exists nothing to do
+		return ctrl.Result{}, nil
+	}
+	if !errors.IsNotFound(err) {
+		log.Error(err, "failed to read application service account", "serviceAccountName", applicationSaName, "namespace", application.Namespace, l.Action, l.ActionView)
+		return ctrl.Result{}, err
+	}
+
+	componentIds, err := r.getComponentIdsForApplication(ctx, application.UID, application.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	pullSecretNames, err := r.getImageRepositoryPullSecretNamesForComponents(ctx, componentIds, application.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// service account doesn't exist we will have to create it
+	err = r.createApplicationServiceAccount(ctx, applicationSaName, application, pullSecretNames)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// getApplicationSaName returns name of application SA
+func getApplicationSaName(applicationName string) string {
+	return fmt.Sprintf("%s-pull", applicationName)
+}
+
+// getComponentIdsForApplication returns components id for all components owned by the application
+func (r *ApplicationPullServiceAccountCreator) getComponentIdsForApplication(ctx context.Context, applicationId types.UID, namespace string) ([]types.UID, error) {
+	log := ctrllog.FromContext(ctx)
+	componentsList := &appstudioredhatcomv1alpha1.ComponentList{}
+	if err := r.Client.List(ctx, componentsList, &client.ListOptions{Namespace: namespace}); err != nil {
+		log.Error(err, "failed to list components")
+		return nil, err
+	}
+
+	allComponentsId := []types.UID{}
+	for _, component := range componentsList.Items {
+		for _, owner := range component.ObjectMeta.OwnerReferences {
+			if owner.UID == applicationId {
+				allComponentsId = append(allComponentsId, component.UID)
+				break
+			}
+		}
+	}
+
+	return allComponentsId, nil
+}
+
+// getImageRepositoryPullSecretNamesForComponents returns pull secret names from imagerepositories owned by provided components
+func (r *ApplicationPullServiceAccountCreator) getImageRepositoryPullSecretNamesForComponents(ctx context.Context, componentIds []types.UID, namespaceName string) ([]string, error) {
+	log := ctrllog.FromContext(ctx)
+	imageRepositoryList := &imagerepositoryv1alpha1.ImageRepositoryList{}
+	if err := r.Client.List(ctx, imageRepositoryList, &client.ListOptions{Namespace: namespaceName}); err != nil {
+		log.Error(err, "failed to list ImageRepositories", l.Action, l.ActionView)
+		return nil, err
+	}
+
+	pullSecretNames := []string{}
+	for _, imageRepository := range imageRepositoryList.Items {
+		for _, owner := range imageRepository.ObjectMeta.OwnerReferences {
+			found := false
+			for _, componentId := range componentIds {
+				if owner.UID == componentId {
+					if imageRepository.Status.Credentials.PullSecretName != "" {
+						pullSecretNames = append(pullSecretNames, imageRepository.Status.Credentials.PullSecretName)
+					}
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+	}
+	return pullSecretNames, nil
+}
+
+// createApplicationServiceAccount creates application service account with provided pull secrets
+func (r *ApplicationPullServiceAccountCreator) createApplicationServiceAccount(ctx context.Context, serviceAccountName string, application *appstudioredhatcomv1alpha1.Application, pullSecretNames []string) error {
+	log := ctrllog.FromContext(ctx).WithValues("serviceAccountName", serviceAccountName, "namespace", application.Namespace)
+
+	applicationServiceAccount := &corev1.ServiceAccount{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: application.Namespace}, applicationServiceAccount)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "failed to read application service account", l.Action, l.ActionView)
+			return err
+		}
+	} else {
+		return nil
+	}
+
+	// Create service account for application
+	secretsReferences := []corev1.ObjectReference{}
+	imagePullSecretsReferences := []corev1.LocalObjectReference{}
+	for _, secretName := range pullSecretNames {
+		secretsReferences = append(secretsReferences, corev1.ObjectReference{Name: secretName})
+		imagePullSecretsReferences = append(imagePullSecretsReferences, corev1.LocalObjectReference{Name: secretName})
+	}
+
+	applicationSA := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: application.Namespace,
+		},
+		Secrets:          secretsReferences,
+		ImagePullSecrets: imagePullSecretsReferences,
+	}
+
+	// set serviceAccount ownership to application
+	if err := controllerutil.SetOwnerReference(application, &applicationSA, r.Scheme); err != nil {
+		log.Error(err, "failed to set application as owner of SA", "applicationName", application.Name)
+		return err
+	}
+
+	if err := r.Client.Create(ctx, &applicationSA); err != nil {
+		log.Error(err, "failed to create service account", "serviceAccountName", l.Action, l.ActionAdd)
+		return err
+	}
+
+	log.Info("application service account created", "SecretNames", pullSecretNames)
+	return nil
+}

--- a/internal/controller/application_controller_test.go
+++ b/internal/controller/application_controller_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
+	"github.com/konflux-ci/image-controller/pkg/quay"
+)
+
+var _ = Describe("Application controller", func() {
+	Context("Application service account doesn't exist", func() {
+		var appSaTestNamespace = "application-sa-namespace-test"
+		var applicationKey = types.NamespacedName{Name: "application-sa-test", Namespace: appSaTestNamespace}
+		var component1Key = types.NamespacedName{Name: "component1-test", Namespace: appSaTestNamespace}
+		var component2Key = types.NamespacedName{Name: "component2-test", Namespace: appSaTestNamespace}
+		var imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: appSaTestNamespace}
+		var imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: appSaTestNamespace}
+		var pullSecret1 = "pull-secret1"
+		var pushSecret1 = "push-secret1"
+		var pullSecret2 = "pull-secret2"
+		var pushSecret2 = "push-secret2"
+		var applicationSaName = getApplicationSaName(applicationKey.Name)
+
+		BeforeEach(func() {
+			quay.ResetTestQuayClient()
+		})
+
+		AfterEach(func() {
+			deleteImageRepository(imageRepository2Key)
+			deleteImageRepository(imageRepository1Key)
+			deleteComponent(component1Key)
+			deleteComponent(component2Key)
+			deleteApplication(applicationKey)
+		})
+
+		It("should prepare environment", func() {
+			createNamespace(appSaTestNamespace)
+		})
+
+		It("application SA will be created with no secrets because no components are owned by application", func() {
+			createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			createApplication(applicationConfig{ApplicationKey: applicationKey})
+
+			// wait until application SA is created with no secrets
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSaTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+				}
+				return saCount == 1 && secretsCount == 0
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			saList := getServiceAccountList(appSaTestNamespace)
+			Expect(len(saList)).Should(Equal(1))
+			Expect(saList[0].Name).Should(Equal(applicationSaName))
+			Expect(len(saList[0].Secrets)).Should(Equal(0))
+			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(0))
+			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
+			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(applicationKey.Name))
+		})
+
+		It("application SA will be created with no secrets because component owned by application doesn't own any image repository", func() {
+			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+
+			// create image repository with finalizer so it won't try to provision repo
+			imageConfig1 := imageRepositoryConfig{
+				ResourceKey: &imageRepository1Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+			}
+			ir1 := createImageRepository(imageConfig1)
+
+			// set image repository state to failed so controller will just stop
+			// set also pull & push secret
+			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir1.Status.Credentials.PullSecretName = pullSecret1
+			ir1.Status.Credentials.PushSecretName = pushSecret1
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+
+			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
+
+			// wait until application SA is created with no secrets
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSaTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+				}
+				return saCount == 1 && secretsCount == 0
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			// set component's owner to application
+			component1.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Application",
+				Name:       application.Name,
+				UID:        application.UID,
+			}}
+			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
+
+			// delete application service account so it gets created again and with secret
+			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: appSaTestNamespace})
+
+			// update application to trigger application controller
+			application.Spec.DisplayName = "test-name"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// wait for application SA to contain secret
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSaTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+				}
+				return saCount == 1 && secretsCount == 0
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			saList := getServiceAccountList(appSaTestNamespace)
+			Expect(len(saList)).Should(Equal(1))
+			Expect(saList[0].Name).Should(Equal(applicationSaName))
+			Expect(len(saList[0].Secrets)).Should(Equal(0))
+			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(0))
+			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
+			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(applicationKey.Name))
+		})
+
+		It("application SA will be created with secrets for two components owned by application", func() {
+			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+
+			// create image repository with finalizer so it won't try to provision repo
+			// also without component & application labels so controller won't try any secrets linking
+			imageConfig1 := imageRepositoryConfig{
+				ResourceKey: &imageRepository1Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component1.Name,
+					UID:        component1.UID,
+				}},
+			}
+			imageConfig2 := imageRepositoryConfig{
+				ResourceKey: &imageRepository2Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component2.Name,
+					UID:        component2.UID,
+				}},
+			}
+			ir1 := createImageRepository(imageConfig1)
+			ir2 := createImageRepository(imageConfig2)
+
+			// set image repository state to failed so controller will just stop
+			// set also pull & push secret
+			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir1.Status.Credentials.PullSecretName = pullSecret1
+			ir1.Status.Credentials.PushSecretName = pushSecret1
+			ir2.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir2.Status.Credentials.PullSecretName = pullSecret2
+			ir2.Status.Credentials.PushSecretName = pushSecret2
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
+
+			// set image repository component & application labels
+			ir1.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component1.Name,
+			}
+			ir2.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component2.Name,
+			}
+			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
+
+			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
+
+			// wait until application SA is created with no secrets
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSaTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+				}
+				return saCount == 1 && secretsCount == 0
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			// set component's owner to application
+			component1.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Application",
+				Name:       application.Name,
+				UID:        application.UID,
+			}}
+			component2.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Application",
+				Name:       application.Name,
+				UID:        application.UID,
+			}}
+			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
+
+			// delete application service account so it gets created again and with secret
+			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: appSaTestNamespace})
+
+			// update application to trigger application controller
+			application.Spec.DisplayName = "test-name"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// wait for application SA to contain secret
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSaTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				imagePullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					imagePullSecretsCount = len(saList[0].ImagePullSecrets)
+				}
+				return saCount == 1 && secretsCount == 2 && imagePullSecretsCount == 2
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			saList := getServiceAccountList(appSaTestNamespace)
+			Expect(len(saList)).Should(Equal(1))
+			Expect(saList[0].Name).Should(Equal(applicationSaName))
+			Expect(len(saList[0].Secrets)).Should(Equal(2))
+			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(2))
+
+			secretCounter := map[string]int{}
+			imagePullSecretCounter := map[string]int{}
+			for _, secret := range saList[0].Secrets {
+				secretCounter[secret.Name]++
+			}
+			for _, secret := range saList[0].ImagePullSecrets {
+				imagePullSecretCounter[secret.Name]++
+			}
+
+			Expect(secretCounter[pullSecret1]).Should(Equal(1))
+			Expect(secretCounter[pullSecret2]).Should(Equal(1))
+			Expect(imagePullSecretCounter[pullSecret1]).Should(Equal(1))
+			Expect(imagePullSecretCounter[pullSecret2]).Should(Equal(1))
+			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
+			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(application.Name))
+		})
+
+		It("should cleanup environment", func() {
+			deleteNamespace(appSaTestNamespace)
+		})
+	})
+})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("../..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "config", "crd", "bases"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "redhat-appstudio", "application-api@"+applicationApiDepVersion, "config", "crd", "bases"),
 		},
 		ErrorIfCRDPathMissing: true,
@@ -124,6 +124,12 @@ var _ = BeforeSuite(func() {
 		Scheme:           k8sManager.GetScheme(),
 		BuildQuayClient:  func(l logr.Logger) quay.QuayService { return quay.TestQuayClient{} },
 		QuayOrganization: quay.TestQuayOrg,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&ApplicationPullServiceAccountCreator{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
new application controller which will create application SA if it doesn't exist and add there all secrets from owned component's imagerepositories

link push secret also to component's SA alongside with current appstudio-pipeline SA

link pull secret to application SA

[STONEBLD-3246](https://issues.redhat.com//browse/STONEBLD-3246)