### PR TITLE
Fix test reference to config/crd/bases

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join("../..", "config", "crd", "bases"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "redhat-appstudio", "application-api@"+applicationApiDepVersion, "config", "crd", "bases"),
 		},
 		ErrorIfCRDPathMissing: true,


### PR DESCRIPTION
The controller directory got moved from `controllers` directory to `internal/controller` in 60686d3.

Test setup is expecting the `config/crd/bases` to be one directory above the test file, but due to the addition of the `internal` directory, it is now two directories above.