### PR TITLE
fix(KFLUXSPRT-2659): always create a pull secret

### DIFF
--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -354,11 +354,9 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 	}
 
 	var pullCredentialsInfo *imageRepositoryAccessData
-	if isComponentLinked(imageRepository) {
-		pullCredentialsInfo, err = r.ProvisionImageRepositoryAccess(ctx, imageRepository, true)
-		if err != nil {
-			return err
-		}
+	pullCredentialsInfo, err = r.ProvisionImageRepositoryAccess(ctx, imageRepository, true)
+	if err != nil {
+		return err
 	}
 
 	if err = r.GrantRepositoryAccessToTeam(ctx, imageRepository); err != nil {
@@ -377,10 +375,8 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 	status.Credentials.GenerationTimestamp = &metav1.Time{Time: time.Now()}
 	status.Credentials.PushRobotAccountName = pushCredentialsInfo.RobotAccountName
 	status.Credentials.PushSecretName = pushCredentialsInfo.SecretName
-	if isComponentLinked(imageRepository) {
-		status.Credentials.PullRobotAccountName = pullCredentialsInfo.RobotAccountName
-		status.Credentials.PullSecretName = pullCredentialsInfo.SecretName
-	}
+	status.Credentials.PullRobotAccountName = pullCredentialsInfo.RobotAccountName
+	status.Credentials.PullSecretName = pullCredentialsInfo.SecretName
 	status.Notifications = notificationStatus
 
 	imageRepository.Spec.Image.Name = imageRepositoryName


### PR DESCRIPTION
We currently only produce a pull secret if a component is linked. Changing the behavior to always create a pull secret so that a pull-only token can be shared with external parties if needed.

resolves: [KFLUXSPRT-2659](https://issues.redhat.com//browse/KFLUXSPRT-2659)