### PR TITLE
Automerge GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,14 @@
       "matchPackageNames": [
         "registry.access.redhat.com/ubi9/go-toolset"
       ],
-      "allowedVersions": [
-        "<2"
-      ]
+      "allowedVersions": "<2"
+    },
+    {
+      "description": "Automerge GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
There is a lot of pull requests created for the repository that update dependencies.
Reviewing all of them manually takes time and usually isn't much more thorough than checking if the CI passes anyway.

Introduce a new package rule that automerges GH Actions.
GH Actions should be safe to update because the particular action would fail in the PR

Note: `allowedVersions` is changed from an array based on the recommendation from Renovate config lint