### PR TITLE
Create application pull secret and link it to integration SA

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,7 +224,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ApplicationPullServiceAccountCreator{
+	if err = (&controllers.ApplicationPullSecretCreator{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,14 +36,23 @@ import (
 	appstudioredhatcomv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 )
 
-// ApplicationPullServiceAccountCreator reconciles a Application object
-type ApplicationPullServiceAccountCreator struct {
+const NamespaceServiceAccountName = "konflux-integration-runner"
+
+// dockerConfigJson represents the structure of a .dockerconfigjson secret
+type dockerConfigJson struct {
+	Auths map[string]struct {
+		Auth string `json:"auth"`
+	} `json:"auths"`
+}
+
+// ApplicationPullSecretCreator reconciles an Application object
+type ApplicationPullSecretCreator struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ApplicationPullServiceAccountCreator) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ApplicationPullSecretCreator) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appstudioredhatcomv1alpha1.Application{}).
 		Complete(r)
@@ -53,7 +63,7 @@ func (r *ApplicationPullServiceAccountCreator) SetupWithManager(mgr ctrl.Manager
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
-func (r *ApplicationPullServiceAccountCreator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ApplicationPullSecretCreator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx).WithName("Application")
 	ctx = ctrllog.IntoContext(ctx, log)
 
@@ -74,45 +84,41 @@ func (r *ApplicationPullServiceAccountCreator) Reconcile(ctx context.Context, re
 		return ctrl.Result{}, nil
 	}
 
-	// fetch application SA
-	applicationSaName := getApplicationSaName(application.Name)
-	applicationServiceAccount := &corev1.ServiceAccount{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: applicationSaName, Namespace: application.Namespace}, applicationServiceAccount)
-	if err == nil {
-		// service account already exists nothing to do
-		return ctrl.Result{}, nil
-	}
-	if !errors.IsNotFound(err) {
-		log.Error(err, "failed to read application service account", "serviceAccountName", applicationSaName, "namespace", application.Namespace, l.Action, l.ActionView)
-		return ctrl.Result{}, err
-	}
-
-	componentIds, err := r.getComponentIdsForApplication(ctx, application.UID, application.Namespace)
+	applicationPullSecretName := getApplicationPullSecretName(application.Name)
+	applicationPullSecretExists, err := r.doesApplicationPullSecretExist(ctx, applicationPullSecretName, application)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if !applicationPullSecretExists {
+		componentIds, err := r.getComponentIdsForApplication(ctx, application.UID, application.Namespace)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	pullSecretNames, err := r.getImageRepositoryPullSecretNamesForComponents(ctx, componentIds, application.Namespace)
-	if err != nil {
-		return ctrl.Result{}, err
+		pullSecretNames, err := r.getImageRepositoryPullSecretNamesForComponents(ctx, componentIds, application.Namespace)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if err := r.createApplicationPullSecret(ctx, applicationPullSecretName, application, pullSecretNames); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
-	// service account doesn't exist we will have to create it
-	err = r.createApplicationServiceAccount(ctx, applicationSaName, application, pullSecretNames)
-	if err != nil {
+	if err := r.updateServiceAccountWithApplicationPullSecret(ctx, applicationPullSecretName, application.Namespace); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-// getApplicationSaName returns name of application SA
-func getApplicationSaName(applicationName string) string {
+// getApplicationPullSecretName returns name for the application pull dockerconfigjson secret
+func getApplicationPullSecretName(applicationName string) string {
 	return fmt.Sprintf("%s-pull", applicationName)
 }
 
 // getComponentIdsForApplication returns components id for all components owned by the application
-func (r *ApplicationPullServiceAccountCreator) getComponentIdsForApplication(ctx context.Context, applicationId types.UID, namespace string) ([]types.UID, error) {
+func (r *ApplicationPullSecretCreator) getComponentIdsForApplication(ctx context.Context, applicationId types.UID, namespace string) ([]types.UID, error) {
 	log := ctrllog.FromContext(ctx)
 	componentsList := &appstudioredhatcomv1alpha1.ComponentList{}
 	if err := r.Client.List(ctx, componentsList, &client.ListOptions{Namespace: namespace}); err != nil {
@@ -134,7 +140,7 @@ func (r *ApplicationPullServiceAccountCreator) getComponentIdsForApplication(ctx
 }
 
 // getImageRepositoryPullSecretNamesForComponents returns pull secret names from imagerepositories owned by provided components
-func (r *ApplicationPullServiceAccountCreator) getImageRepositoryPullSecretNamesForComponents(ctx context.Context, componentIds []types.UID, namespaceName string) ([]string, error) {
+func (r *ApplicationPullSecretCreator) getImageRepositoryPullSecretNamesForComponents(ctx context.Context, componentIds []types.UID, namespaceName string) ([]string, error) {
 	log := ctrllog.FromContext(ctx)
 	imageRepositoryList := &imagerepositoryv1alpha1.ImageRepositoryList{}
 	if err := r.Client.List(ctx, imageRepositoryList, &client.ListOptions{Namespace: namespaceName}); err != nil {
@@ -163,49 +169,159 @@ func (r *ApplicationPullServiceAccountCreator) getImageRepositoryPullSecretNames
 	return pullSecretNames, nil
 }
 
-// createApplicationServiceAccount creates application service account with provided pull secrets
-func (r *ApplicationPullServiceAccountCreator) createApplicationServiceAccount(ctx context.Context, serviceAccountName string, application *appstudioredhatcomv1alpha1.Application, pullSecretNames []string) error {
-	log := ctrllog.FromContext(ctx).WithValues("serviceAccountName", serviceAccountName, "namespace", application.Namespace)
+// createApplicationPullSecret creates or updates a single kubernetes.io/dockerconfigjson secret
+// by combining data from individual pull secrets.
+func (r *ApplicationPullSecretCreator) createApplicationPullSecret(ctx context.Context, applicationPullSecretName string, application *appstudioredhatcomv1alpha1.Application, individualSecretNames []string) error {
+	log := ctrllog.FromContext(ctx)
 
-	applicationServiceAccount := &corev1.ServiceAccount{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: application.Namespace}, applicationServiceAccount)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			log.Error(err, "failed to read application service account", l.Action, l.ActionView)
-			return err
+	log.Info("Creating application pull secret", "secretName", applicationPullSecretName)
+
+	combinedAuths := make(map[string]struct {
+		Auth string `json:"auth"`
+	})
+
+	secretList := &corev1.SecretList{}
+	if err := r.Client.List(ctx, secretList, &client.ListOptions{Namespace: application.Namespace}); err != nil {
+		log.Error(err, "failed to list secrets", l.Action, l.ActionView)
+		return err
+	}
+
+	for _, secret := range secretList.Items {
+		shouldProcess := false
+		for _, name := range individualSecretNames {
+			if secret.Name == name {
+				shouldProcess = true
+				break
+			}
 		}
-	} else {
-		return nil
+		if !shouldProcess {
+			continue
+		}
+
+		// Only process secrets of type kubernetes.io/dockerconfigjson
+		if secret.Type != corev1.SecretTypeDockerConfigJson {
+			continue
+		}
+
+		// Secret missing .dockerconfigjson key
+		dockerConfigDataBytes, ok := secret.Data[corev1.DockerConfigJsonKey]
+		if !ok {
+			continue
+		}
+
+		var dcj dockerConfigJson
+		if err := json.Unmarshal(dockerConfigDataBytes, &dcj); err != nil {
+			log.Error(err, "failed to unmarshal .dockerconfigjson data from secret", "secretName", secret.Name)
+			continue
+		}
+
+		for registry, authEntry := range dcj.Auths {
+			combinedAuths[registry] = authEntry
+		}
 	}
 
-	// Create service account for application
-	secretsReferences := []corev1.ObjectReference{}
-	imagePullSecretsReferences := []corev1.LocalObjectReference{}
-	for _, secretName := range pullSecretNames {
-		secretsReferences = append(secretsReferences, corev1.ObjectReference{Name: secretName})
-		imagePullSecretsReferences = append(imagePullSecretsReferences, corev1.LocalObjectReference{Name: secretName})
+	// Marshal combined auths back into .dockerconfigjson format
+	combinedDockerConfig := dockerConfigJson{Auths: combinedAuths}
+	marshaledData, err := json.Marshal(combinedDockerConfig)
+	if err != nil {
+		log.Error(err, "failed to marshal combined docker config json")
+		return err
 	}
 
-	applicationSA := corev1.ServiceAccount{
+	// Create the application pull secret
+	applicationPullSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceAccountName,
+			Name:      applicationPullSecretName,
 			Namespace: application.Namespace,
 		},
-		Secrets:          secretsReferences,
-		ImagePullSecrets: imagePullSecretsReferences,
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: marshaledData,
+		},
 	}
 
-	// set serviceAccount ownership to application
-	if err := controllerutil.SetOwnerReference(application, &applicationSA, r.Scheme); err != nil {
-		log.Error(err, "failed to set application as owner of SA", "applicationName", application.Name)
+	// Set pull secret ownership to application
+	if err := controllerutil.SetOwnerReference(application, applicationPullSecret, r.Scheme); err != nil {
+		log.Error(err, "failed to set application as owner of application pull secret", "applicationName", application.Name)
 		return err
 	}
 
-	if err := r.Client.Create(ctx, &applicationSA); err != nil {
-		log.Error(err, "failed to create service account", "serviceAccountName", l.Action, l.ActionAdd)
+	if err := r.Client.Create(ctx, applicationPullSecret); err != nil {
+		log.Error(err, "failed to create application pull secret", "secretName", applicationPullSecretName, l.Action, l.ActionAdd)
 		return err
 	}
 
-	log.Info("application service account created", "SecretNames", pullSecretNames)
+	log.Info("Application pull secret created successfully", "secretName", applicationPullSecretName)
 	return nil
+}
+
+// udateServiceAccountWithApplicationPullSecret updates the ServiceAccount to include
+// the application pull secret as an imagePullSecret and as a Secret
+func (r *ApplicationPullSecretCreator) updateServiceAccountWithApplicationPullSecret(ctx context.Context, applicationPullSecretName string, namespace string) error {
+	log := ctrllog.FromContext(ctx)
+
+	// fetch namespace SA
+	namespaceServiceAccount := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: namespace}, namespaceServiceAccount); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Namespace ServiceAccount not found", "serviceAccountName", NamespaceServiceAccountName, "namespace", namespace)
+			return nil
+		}
+		log.Error(err, "failed to read namespace ServiceAccount", "serviceAccountName", NamespaceServiceAccountName, "namespace", namespace, l.Action, l.ActionView)
+		return err
+	}
+
+	// Check and update Secrets
+	secretLinked := false
+	shouldUpdateServiceAccount := false
+	for _, secret := range namespaceServiceAccount.Secrets {
+		if secret.Name == applicationPullSecretName {
+			secretLinked = true
+			break
+		}
+	}
+	if !secretLinked {
+		namespaceServiceAccount.Secrets = append(namespaceServiceAccount.Secrets, corev1.ObjectReference{Name: applicationPullSecretName})
+		shouldUpdateServiceAccount = true
+	}
+
+	// Check and update imagePullSecrets
+	secretLinked = false
+	for _, pullSecret := range namespaceServiceAccount.ImagePullSecrets {
+		if pullSecret.Name == applicationPullSecretName {
+			secretLinked = true
+			break
+		}
+	}
+
+	if !secretLinked {
+		namespaceServiceAccount.ImagePullSecrets = append(namespaceServiceAccount.ImagePullSecrets, corev1.LocalObjectReference{Name: applicationPullSecretName})
+		shouldUpdateServiceAccount = true
+	}
+
+	if shouldUpdateServiceAccount {
+		if err := r.Client.Update(ctx, namespaceServiceAccount); err != nil {
+			log.Error(err, "failed to update Service Account with application pull secret", l.Action, l.ActionUpdate)
+			return err
+		}
+		log.Info("Service Account updated successfully with application pull secret.", "secretName", applicationPullSecretName)
+	}
+
+	return nil
+}
+
+func (r *ApplicationPullSecretCreator) doesApplicationPullSecretExist(ctx context.Context, applicationPullSecretName string, application *appstudioredhatcomv1alpha1.Application) (bool, error) {
+	log := ctrllog.FromContext(ctx)
+
+	applicationPullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: applicationPullSecretName, Namespace: application.Namespace}, applicationPullSecret); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		log.Error(err, "failed to get application pull secret", "secretName", applicationPullSecretName, l.Action, l.ActionView)
+		return false, err
+	}
+
+	return true, nil
 }

--- a/internal/controller/application_controller_test.go
+++ b/internal/controller/application_controller_test.go
@@ -16,31 +16,47 @@ limitations under the License.
 package controllers
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
 	"github.com/konflux-ci/image-controller/pkg/quay"
 )
 
+const KonfluxIntegrationRunnerSAName = "konflux-integration-runner"
+
 var _ = Describe("Application controller", func() {
-	Context("Application service account doesn't exist", func() {
-		var appSaTestNamespace = "application-sa-namespace-test"
-		var applicationKey = types.NamespacedName{Name: "application-sa-test", Namespace: appSaTestNamespace}
-		var component1Key = types.NamespacedName{Name: "component1-test", Namespace: appSaTestNamespace}
-		var component2Key = types.NamespacedName{Name: "component2-test", Namespace: appSaTestNamespace}
-		var imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: appSaTestNamespace}
-		var imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: appSaTestNamespace}
-		var pullSecret1 = "pull-secret1"
-		var pushSecret1 = "push-secret1"
-		var pullSecret2 = "pull-secret2"
-		var pushSecret2 = "push-secret2"
-		var applicationSaName = getApplicationSaName(applicationKey.Name)
+	var testNamespace string
+	var applicationKey types.NamespacedName
+	var component1Key types.NamespacedName
+	var component2Key types.NamespacedName
+	var imageRepository1Key types.NamespacedName
+	var imageRepository2Key types.NamespacedName
+
+	var aggregatedPullSecretName types.NamespacedName
+
+	Context("ServiceAccount 'konflux-integration-runner' exists", func() {
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
+			testNamespace = fmt.Sprintf("test-ns-%d", time.Now().UnixNano())
+			createNamespace(testNamespace)
+			createServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			applicationKey = types.NamespacedName{Name: "application-test", Namespace: testNamespace}
+			component1Key = types.NamespacedName{Name: "component1-test", Namespace: testNamespace}
+			component2Key = types.NamespacedName{Name: "component2-test", Namespace: testNamespace}
+			imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: testNamespace}
+			imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: testNamespace}
+			createApplication(applicationConfig{ApplicationKey: applicationKey})
+			aggregatedPullSecretName = types.NamespacedName{Name: getApplicationPullSecretName(applicationKey.Name), Namespace: testNamespace}
+
 		})
 
 		AfterEach(func() {
@@ -49,168 +65,27 @@ var _ = Describe("Application controller", func() {
 			deleteComponent(component1Key)
 			deleteComponent(component2Key)
 			deleteApplication(applicationKey)
+			deleteSecret(aggregatedPullSecretName)
+			deleteSecret(types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace})
+			deleteSecret(types.NamespacedName{Name: "pull-secret-comp2", Namespace: testNamespace})
+			deleteSecret(types.NamespacedName{Name: "pull-secret-comp1-rotated", Namespace: testNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: testNamespace})
+			deleteNamespace(testNamespace)
 		})
 
-		It("should prepare environment", func() {
-			createNamespace(appSaTestNamespace)
-		})
+		It("should create an aggregated pull secret and link it to 'konflux-integration-runner' SA", func() {
+			pullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data)
 
-		It("application SA will be created with no secrets because no components are owned by application", func() {
-			createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			createApplication(applicationConfig{ApplicationKey: applicationKey})
+			pullSecret2Data := generateDockerConfigJson("registry2.example.com", "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: "pull-secret-comp2", Namespace: testNamespace}
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data)
 
-			// wait until application SA is created with no secrets
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-				}
-				return saCount == 1 && secretsCount == 0
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
-
-			saList := getServiceAccountList(appSaTestNamespace)
-			Expect(len(saList)).Should(Equal(1))
-			Expect(saList[0].Name).Should(Equal(applicationSaName))
-			Expect(len(saList[0].Secrets)).Should(Equal(0))
-			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(0))
-			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
-			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(applicationKey.Name))
-		})
-
-		It("application SA will be created with no secrets because component owned by application doesn't own any image repository", func() {
-			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-
-			// create image repository with finalizer so it won't try to provision repo
-			imageConfig1 := imageRepositoryConfig{
-				ResourceKey: &imageRepository1Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
-			}
-			ir1 := createImageRepository(imageConfig1)
-
-			// set image repository state to failed so controller will just stop
-			// set also pull & push secret
-			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
-			ir1.Status.Credentials.PullSecretName = pullSecret1
-			ir1.Status.Credentials.PushSecretName = pushSecret1
-			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
-
-			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
-
-			// wait until application SA is created with no secrets
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-				}
-				return saCount == 1 && secretsCount == 0
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
-
-			// set component's owner to application
-			component1.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion: "appstudio.redhat.com/v1alpha1",
-				Kind:       "Application",
-				Name:       application.Name,
-				UID:        application.UID,
-			}}
-			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
-
-			// delete application service account so it gets created again and with secret
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: appSaTestNamespace})
-
-			// update application to trigger application controller
-			application.Spec.DisplayName = "test-name"
-			Expect(k8sClient.Update(ctx, application)).To(Succeed())
-
-			// wait for application SA to contain secret
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-				}
-				return saCount == 1 && secretsCount == 0
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
-
-			saList := getServiceAccountList(appSaTestNamespace)
-			Expect(len(saList)).Should(Equal(1))
-			Expect(saList[0].Name).Should(Equal(applicationSaName))
-			Expect(len(saList[0].Secrets)).Should(Equal(0))
-			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(0))
-			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
-			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(applicationKey.Name))
-		})
-
-		It("application SA will be created with secrets for two components owned by application", func() {
 			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
 			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
 
-			// create image repository with finalizer so it won't try to provision repo
-			// also without component & application labels so controller won't try any secrets linking
-			imageConfig1 := imageRepositoryConfig{
-				ResourceKey: &imageRepository1Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Component",
-					Name:       component1.Name,
-					UID:        component1.UID,
-				}},
-			}
-			imageConfig2 := imageRepositoryConfig{
-				ResourceKey: &imageRepository2Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Component",
-					Name:       component2.Name,
-					UID:        component2.UID,
-				}},
-			}
-			ir1 := createImageRepository(imageConfig1)
-			ir2 := createImageRepository(imageConfig2)
-
-			// set image repository state to failed so controller will just stop
-			// set also pull & push secret
-			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
-			ir1.Status.Credentials.PullSecretName = pullSecret1
-			ir1.Status.Credentials.PushSecretName = pushSecret1
-			ir2.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
-			ir2.Status.Credentials.PullSecretName = pullSecret2
-			ir2.Status.Credentials.PushSecretName = pushSecret2
-			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
-			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
-
-			// set image repository component & application labels
-			ir1.Labels = map[string]string{
-				ApplicationNameLabelName: applicationKey.Name,
-				ComponentNameLabelName:   component1.Name,
-			}
-			ir2.Labels = map[string]string{
-				ApplicationNameLabelName: applicationKey.Name,
-				ComponentNameLabelName:   component2.Name,
-			}
-			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
-			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
-
-			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
-
-			// wait until application SA is created with no secrets
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-				}
-				return saCount == 1 && secretsCount == 0
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
-
-			// set component's owner to application
+			application := getApplication(applicationKey)
 			component1.OwnerReferences = []metav1.OwnerReference{{
 				APIVersion: "appstudio.redhat.com/v1alpha1",
 				Kind:       "Application",
@@ -226,51 +101,224 @@ var _ = Describe("Application controller", func() {
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
 
-			// delete application service account so it gets created again and with secret
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: appSaTestNamespace})
+			ir1 := createImageRepository(imageRepositoryConfig{
+				ResourceKey:     &imageRepository1Key,
+				Finalizers:      []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component1.Name, UID: component1.UID}},
+			})
+			ir1.Status.Credentials.PullSecretName = pullSecret1Key.Name
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
 
-			// update application to trigger application controller
-			application.Spec.DisplayName = "test-name"
+			ir2 := createImageRepository(imageRepositoryConfig{
+				ResourceKey:     &imageRepository2Key,
+				Finalizers:      []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component2.Name, UID: component2.UID}},
+			})
+			ir2.Status.Credentials.PullSecretName = pullSecret2Key.Name
+			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
+
+			// Trigger reconciliation by updating the application
+			application.Spec.DisplayName = "updated-name"
 			Expect(k8sClient.Update(ctx, application)).To(Succeed())
 
-			// wait for application SA to contain secret
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				imagePullSecretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-					imagePullSecretsCount = len(saList[0].ImagePullSecrets)
-				}
-				return saCount == 1 && secretsCount == 2 && imagePullSecretsCount == 2
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+			// Assert the aggregated secret is created and its content is correct
+			aggregatedSecret := &corev1.Secret{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
+			}, timeout, interval).Should(Succeed(), "Expected aggregated pull secret to be created")
 
-			saList := getServiceAccountList(appSaTestNamespace)
-			Expect(len(saList)).Should(Equal(1))
-			Expect(saList[0].Name).Should(Equal(applicationSaName))
-			Expect(len(saList[0].Secrets)).Should(Equal(2))
-			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(2))
+			Expect(aggregatedSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(aggregatedSecret.OwnerReferences).To(HaveLen(1))
+			Expect(aggregatedSecret.OwnerReferences[0].Name).To(Equal(applicationKey.Name))
+			Expect(aggregatedSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
 
-			secretCounter := map[string]int{}
-			imagePullSecretCounter := map[string]int{}
-			for _, secret := range saList[0].Secrets {
-				secretCounter[secret.Name]++
-			}
-			for _, secret := range saList[0].ImagePullSecrets {
-				imagePullSecretCounter[secret.Name]++
-			}
+			aggregatedSecretDockerConfigJson := string(aggregatedSecret.Data[corev1.DockerConfigJsonKey])
 
-			Expect(secretCounter[pullSecret1]).Should(Equal(1))
-			Expect(secretCounter[pullSecret2]).Should(Equal(1))
-			Expect(imagePullSecretCounter[pullSecret1]).Should(Equal(1))
-			Expect(imagePullSecretCounter[pullSecret2]).Should(Equal(1))
-			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
-			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(application.Name))
+			var decodedAggregated dockerConfigJson
+			Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
+
+			Expect(decodedAggregated.Auths).To(HaveLen(2))
+			Expect(decodedAggregated.Auths).To(HaveKey("registry1.example.com"))
+			Expect(decodedAggregated.Auths["registry1.example.com"].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte("user1:pass1"))))
+			Expect(decodedAggregated.Auths).To(HaveKey("registry2.example.com"))
+			Expect(decodedAggregated.Auths["registry2.example.com"].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte("user2:pass2"))))
+
+			// Assert 'konflux-integration-runner' SA links the aggregated secret
+			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
 		})
 
-		It("should cleanup environment", func() {
-			deleteNamespace(appSaTestNamespace)
+		It("should update the aggregated pull secret on individual secret rotation", func() {
+			pullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data)
+
+			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			application := getApplication(applicationKey)
+			component1.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Application", Name: application.Name, UID: application.UID,
+			}}
+			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
+
+			ir1 := createImageRepository(imageRepositoryConfig{
+				ResourceKey:     &imageRepository1Key,
+				Finalizers:      []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component1.Name, UID: component1.UID}},
+			})
+			ir1.Status.Credentials.PullSecretName = pullSecret1Key.Name
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+
+			// Trigger initial reconciliation
+			application.Spec.DisplayName = "initial-reconcile"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// Wait for aggregated secret to be created
+			aggregatedSecret := &corev1.Secret{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
+			}, timeout, interval).Should(Succeed())
+
+			// Rotate credentials: update the individual secret
+			rotatedPullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1-new", "pass1-new")
+			updatedSecret := waitSecretExist(pullSecret1Key)
+			updatedSecret.Data[corev1.DockerConfigJsonKey] = []byte(rotatedPullSecret1Data)
+			Expect(k8sClient.Update(ctx, updatedSecret)).To(Succeed())
+
+			// Trigger reconciliation by updating the application
+			application.Spec.DisplayName = "rotated-reconcile"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// Assert aggregated secret is updated with new credentials
+			Eventually(func() bool {
+				currentAggregatedSecret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, aggregatedPullSecretName, currentAggregatedSecret)
+				if err != nil {
+					return false
+				}
+				aggregatedSecretDockerConfigJson := string(currentAggregatedSecret.Data[corev1.DockerConfigJsonKey])
+
+				var decodedAggregated dockerConfigJson
+				Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
+
+				return decodedAggregated.Auths["registry1.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user1-new:pass1-new"))
+			}, timeout, interval).Should(BeTrue(), "Expected aggregated pull secret to be updated with rotated credentials")
+
+			// Ensure SA still links the same aggregated secret
+			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
+		})
+
+		It("should remove credentials from aggregated pull secret on individual secret deletion", func() {
+			pullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data)
+
+			pullSecret2Data := generateDockerConfigJson("registry2.example.com", "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: "pull-secret-comp2", Namespace: testNamespace}
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data)
+
+			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+			application := getApplication(applicationKey)
+			component1.OwnerReferences = []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Application", Name: application.Name, UID: application.UID}}
+			component2.OwnerReferences = []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Application", Name: application.Name, UID: application.UID}}
+			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
+
+			ir1 := createImageRepository(imageRepositoryConfig{
+				ResourceKey:     &imageRepository1Key,
+				Finalizers:      []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component1.Name, UID: component1.UID}},
+			})
+			ir1.Status.Credentials.PullSecretName = pullSecret1Key.Name
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+
+			ir2 := createImageRepository(imageRepositoryConfig{
+				ResourceKey:     &imageRepository2Key,
+				Finalizers:      []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component2.Name, UID: component2.UID}},
+			})
+			ir2.Status.Credentials.PullSecretName = pullSecret2Key.Name
+			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
+
+			// Trigger initial reconciliation
+			application.Spec.DisplayName = "initial-reconcile-delete"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// Wait for aggregated secret to be created with both entries
+			aggregatedSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
+				if err != nil {
+					return false
+				}
+				aggregatedSecretDockerConfigJson := string(aggregatedSecret.Data[corev1.DockerConfigJsonKey])
+
+				var decodedAggregated dockerConfigJson
+				Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
+				return len(decodedAggregated.Auths) == 2 &&
+					decodedAggregated.Auths["registry1.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user1:pass1")) &&
+					decodedAggregated.Auths["registry2.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user2:pass2"))
+			}, timeout, interval).Should(BeTrue(), "Expected aggregated secret to have both initial entries")
+
+			// Delete one of the individual secrets
+			deleteSecret(pullSecret1Key)
+
+			// Trigger reconciliation by updating the application
+			application.Spec.DisplayName = "delete-reconcile"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// Assert aggregated secret no longer contains the deleted entry
+			Eventually(func() bool {
+				currentAggregatedSecret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, aggregatedPullSecretName, currentAggregatedSecret)
+				if err != nil {
+					return false
+				}
+				aggregatedSecretDockerConfigJson := string(currentAggregatedSecret.Data[corev1.DockerConfigJsonKey])
+
+				var decodedAggregated dockerConfigJson
+				Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
+				// Should only have one entry left (registry2.example.com)
+				_, registry1Exists := decodedAggregated.Auths["registry1.example.com"]
+				return len(decodedAggregated.Auths) == 1 &&
+					decodedAggregated.Auths["registry2.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user2:pass2")) &&
+					!registry1Exists
+			}, timeout, interval).Should(BeTrue(), "Expected aggregated pull secret to remove deleted entry")
+
+			// Ensure SA still links the same aggregated secret
+			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
+		})
+
+		It("should handle empty list of individual secrets gracefully", func() {
+			// Trigger reconciliation by updating the application
+			application := getApplication(applicationKey)
+			application.Spec.DisplayName = "empty-reconcile"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
+
+			// Assert aggregated secret is created, but its data is empty
+			aggregatedSecret := &corev1.Secret{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
+			}, timeout, interval).Should(Succeed(), "Expected aggregated pull secret to be created")
+
+			Expect(aggregatedSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(aggregatedSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
+
+			aggregatedSecretDockerConfigJson := string(aggregatedSecret.Data[corev1.DockerConfigJsonKey])
+
+			var decodedAggregated dockerConfigJson
+			Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
+			Expect(decodedAggregated.Auths).To(BeEmpty())
+
+			// Assert 'konflux-integration-runner' SA links the empty aggregated secret
+			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
 		})
 	})
 })

--- a/internal/controller/application_controller_test.go
+++ b/internal/controller/application_controller_test.go
@@ -18,8 +18,6 @@ package controllers
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,65 +25,133 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1"
 	"github.com/konflux-ci/image-controller/pkg/quay"
 )
 
-const KonfluxIntegrationRunnerSAName = "konflux-integration-runner"
-
 var _ = Describe("Application controller", func() {
-	var testNamespace string
-	var applicationKey types.NamespacedName
-	var component1Key types.NamespacedName
-	var component2Key types.NamespacedName
-	var imageRepository1Key types.NamespacedName
-	var imageRepository2Key types.NamespacedName
+	var appSecretTestNamespace = "application-secret-namespace-test"
+	var applicationKey = types.NamespacedName{Name: "application-test", Namespace: appSecretTestNamespace}
+	var component1Key = types.NamespacedName{Name: "component1-test", Namespace: appSecretTestNamespace}
+	var component2Key = types.NamespacedName{Name: "component2-test", Namespace: appSecretTestNamespace}
+	var imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: appSecretTestNamespace}
+	var imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: appSecretTestNamespace}
+	var namespacePullSecretName = types.NamespacedName{Name: getApplicationPullSecretName(applicationKey.Name), Namespace: appSecretTestNamespace}
+	var pullSecret1 = "pull-secret1"
+	var pushSecret1 = "push-secret1"
+	var pullSecret2 = "pull-secret2"
+	var pushSecret2 = "push-secret2"
+	var authSecret1 = "user1:pass1"
+	var authSecret2 = "user2:pass2"
+	var registrySecret1 = "registry1.example.com"
+	var registrySecret2 = "registry2.example.com"
 
-	var aggregatedPullSecretName types.NamespacedName
-
-	Context("ServiceAccount 'konflux-integration-runner' exists", func() {
-
+	Context("Create application secret and link it to Namespace ServiceAccount when it exists", func() {
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
-			testNamespace = fmt.Sprintf("test-ns-%d", time.Now().UnixNano())
-			createNamespace(testNamespace)
-			createServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
-			applicationKey = types.NamespacedName{Name: "application-test", Namespace: testNamespace}
-			component1Key = types.NamespacedName{Name: "component1-test", Namespace: testNamespace}
-			component2Key = types.NamespacedName{Name: "component2-test", Namespace: testNamespace}
-			imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: testNamespace}
-			imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: testNamespace}
-			createApplication(applicationConfig{ApplicationKey: applicationKey})
-			aggregatedPullSecretName = types.NamespacedName{Name: getApplicationPullSecretName(applicationKey.Name), Namespace: testNamespace}
-
 		})
 
 		AfterEach(func() {
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: appSecretTestNamespace})
+			deleteSecret(namespacePullSecretName)
 			deleteImageRepository(imageRepository2Key)
 			deleteImageRepository(imageRepository1Key)
 			deleteComponent(component1Key)
 			deleteComponent(component2Key)
 			deleteApplication(applicationKey)
-			deleteSecret(aggregatedPullSecretName)
-			deleteSecret(types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace})
-			deleteSecret(types.NamespacedName{Name: "pull-secret-comp2", Namespace: testNamespace})
-			deleteSecret(types.NamespacedName{Name: "pull-secret-comp1-rotated", Namespace: testNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: testNamespace})
-			deleteNamespace(testNamespace)
+			deleteSecret(types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace})
+			deleteSecret(types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace})
 		})
 
-		It("should create an aggregated pull secret and link it to 'konflux-integration-runner' SA", func() {
-			pullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1", "pass1")
-			pullSecret1Key := types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace}
-			createDockerConfigSecret(pullSecret1Key, pullSecret1Data)
+		It("should prepare environment", func() {
+			createNamespace(appSecretTestNamespace)
+		})
 
-			pullSecret2Data := generateDockerConfigJson("registry2.example.com", "user2", "pass2")
-			pullSecret2Key := types.NamespacedName{Name: "pull-secret-comp2", Namespace: testNamespace}
-			createDockerConfigSecret(pullSecret2Key, pullSecret2Data)
+		It("should create empty application pull secret and without link it to not existing namespace SA, because no components are owned by application", func() {
+			createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			createApplication(applicationConfig{ApplicationKey: applicationKey})
 
+			// wait until application secret is created
+			applicationSecret := waitSecretExist(namespacePullSecretName)
+
+			// verify that namespace SA doesn't exist
+			saList := getServiceAccountList(appSecretTestNamespace)
+			Expect(len(saList)).Should(Equal(0))
+
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+			Expect(len(decodedSecret.Auths)).Should(Equal(0))
+		})
+
+		It("should create empty application pull secret and link it to namespace SA, because no components are owned by application", func() {
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			createApplication(applicationConfig{ApplicationKey: applicationKey})
+
+			// wait until empty secret is linked to namespace SA
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
+				}
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			saList := getServiceAccountList(appSecretTestNamespace)
+			Expect(len(saList)).Should(Equal(1))
+			Expect(saList[0].Name).Should(Equal(NamespaceServiceAccountName))
+			Expect(len(saList[0].Secrets)).Should(Equal(1))
+			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(1))
+
+			applicationSecret := getSecret(namespacePullSecretName)
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+			Expect(len(decodedSecret.Auths)).Should(Equal(0))
+		})
+
+		It("should create an application pull secret with 2 secrets and link it to namespace SA", func() {
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			pullSecret1Data := generateDockerConfigJson(registrySecret1, "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data, true)
+
+			pullSecret2Data := generateDockerConfigJson(registrySecret2, "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, true)
+
+			// will trigger application controller and create empty secret
+			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
 			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
 			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
 
-			application := getApplication(applicationKey)
+			// wait until empty secret is linked to namespace SA
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
+				}
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			// delete application SA and empty secret as it will be created on next reconcile
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: appSecretTestNamespace})
+			deleteSecret(namespacePullSecretName)
+			// recreate empty SA
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+
+			// set component's owner to application
 			component1.OwnerReferences = []metav1.OwnerReference{{
 				APIVersion: "appstudio.redhat.com/v1alpha1",
 				Kind:       "Application",
@@ -101,224 +167,231 @@ var _ = Describe("Application controller", func() {
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
 
-			ir1 := createImageRepository(imageRepositoryConfig{
-				ResourceKey:     &imageRepository1Key,
-				Finalizers:      []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component1.Name, UID: component1.UID}},
-			})
-			ir1.Status.Credentials.PullSecretName = pullSecret1Key.Name
-			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+			// create image repository with finalizer so it won't try to provision repo
+			// also without component & application labels so controller won't try any secrets linking
+			imageConfig1 := imageRepositoryConfig{
+				ResourceKey: &imageRepository1Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component1.Name,
+					UID:        component1.UID,
+				}},
+			}
+			imageConfig2 := imageRepositoryConfig{
+				ResourceKey: &imageRepository2Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component2.Name,
+					UID:        component2.UID,
+				}},
+			}
+			ir1 := createImageRepository(imageConfig1)
+			ir2 := createImageRepository(imageConfig2)
 
-			ir2 := createImageRepository(imageRepositoryConfig{
-				ResourceKey:     &imageRepository2Key,
-				Finalizers:      []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component2.Name, UID: component2.UID}},
-			})
-			ir2.Status.Credentials.PullSecretName = pullSecret2Key.Name
+			// set image repository state to failed so controller will just stop
+			// set also pull & push secret
+			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir1.Status.Credentials.PullSecretName = pullSecret1
+			ir1.Status.Credentials.PushSecretName = pushSecret1
+			ir2.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir2.Status.Credentials.PullSecretName = pullSecret2
+			ir2.Status.Credentials.PushSecretName = pushSecret2
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
 			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
+
+			// set image repository component & application labels
+			ir1.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component1.Name,
+			}
+			ir2.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component2.Name,
+			}
+			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
 
 			// Trigger reconciliation by updating the application
 			application.Spec.DisplayName = "updated-name"
 			Expect(k8sClient.Update(ctx, application)).To(Succeed())
 
-			// Assert the aggregated secret is created and its content is correct
-			aggregatedSecret := &corev1.Secret{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
-			}, timeout, interval).Should(Succeed(), "Expected aggregated pull secret to be created")
-
-			Expect(aggregatedSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
-			Expect(aggregatedSecret.OwnerReferences).To(HaveLen(1))
-			Expect(aggregatedSecret.OwnerReferences[0].Name).To(Equal(applicationKey.Name))
-			Expect(aggregatedSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
-
-			aggregatedSecretDockerConfigJson := string(aggregatedSecret.Data[corev1.DockerConfigJsonKey])
-
-			var decodedAggregated dockerConfigJson
-			Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
-
-			Expect(decodedAggregated.Auths).To(HaveLen(2))
-			Expect(decodedAggregated.Auths).To(HaveKey("registry1.example.com"))
-			Expect(decodedAggregated.Auths["registry1.example.com"].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte("user1:pass1"))))
-			Expect(decodedAggregated.Auths).To(HaveKey("registry2.example.com"))
-			Expect(decodedAggregated.Auths["registry2.example.com"].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte("user2:pass2"))))
-
-			// Assert 'konflux-integration-runner' SA links the aggregated secret
-			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
-			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
-			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
-		})
-
-		It("should update the aggregated pull secret on individual secret rotation", func() {
-			pullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1", "pass1")
-			pullSecret1Key := types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace}
-			createDockerConfigSecret(pullSecret1Key, pullSecret1Data)
-
-			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			application := getApplication(applicationKey)
-			component1.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Application", Name: application.Name, UID: application.UID,
-			}}
-			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
-
-			ir1 := createImageRepository(imageRepositoryConfig{
-				ResourceKey:     &imageRepository1Key,
-				Finalizers:      []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component1.Name, UID: component1.UID}},
-			})
-			ir1.Status.Credentials.PullSecretName = pullSecret1Key.Name
-			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
-
-			// Trigger initial reconciliation
-			application.Spec.DisplayName = "initial-reconcile"
-			Expect(k8sClient.Update(ctx, application)).To(Succeed())
-
-			// Wait for aggregated secret to be created
-			aggregatedSecret := &corev1.Secret{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
-			}, timeout, interval).Should(Succeed())
-
-			// Rotate credentials: update the individual secret
-			rotatedPullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1-new", "pass1-new")
-			updatedSecret := waitSecretExist(pullSecret1Key)
-			updatedSecret.Data[corev1.DockerConfigJsonKey] = []byte(rotatedPullSecret1Data)
-			Expect(k8sClient.Update(ctx, updatedSecret)).To(Succeed())
-
-			// Trigger reconciliation by updating the application
-			application.Spec.DisplayName = "rotated-reconcile"
-			Expect(k8sClient.Update(ctx, application)).To(Succeed())
-
-			// Assert aggregated secret is updated with new credentials
+			// wait until empty secret is linked to namespace SA
 			Eventually(func() bool {
-				currentAggregatedSecret := &corev1.Secret{}
-				err := k8sClient.Get(ctx, aggregatedPullSecretName, currentAggregatedSecret)
-				if err != nil {
-					return false
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
 				}
-				aggregatedSecretDockerConfigJson := string(currentAggregatedSecret.Data[corev1.DockerConfigJsonKey])
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 
-				var decodedAggregated dockerConfigJson
-				Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
+			applicationSecret := getSecret(namespacePullSecretName)
 
-				return decodedAggregated.Auths["registry1.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user1-new:pass1-new"))
-			}, timeout, interval).Should(BeTrue(), "Expected aggregated pull secret to be updated with rotated credentials")
+			Expect(applicationSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(applicationSecret.OwnerReferences).To(HaveLen(1))
+			Expect(applicationSecret.OwnerReferences[0].Name).To(Equal(applicationKey.Name))
+			Expect(applicationSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
 
-			// Ensure SA still links the same aggregated secret
-			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+
+			Expect(decodedSecret.Auths).To(HaveLen(2))
+			Expect(decodedSecret.Auths).To(HaveKey(registrySecret1))
+			Expect(decodedSecret.Auths[registrySecret1].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte(authSecret1))))
+			Expect(decodedSecret.Auths).To(HaveKey(registrySecret2))
+			Expect(decodedSecret.Auths[registrySecret2].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte(authSecret2))))
+
+			konfluxSA := getServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
 			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
-			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(namespacePullSecretName.Name))
+			Expect(konfluxSA.Secrets).To(HaveLen(1))
+			Expect(konfluxSA.Secrets[0].Name).To(Equal(namespacePullSecretName.Name))
 		})
 
-		It("should remove credentials from aggregated pull secret on individual secret deletion", func() {
-			pullSecret1Data := generateDockerConfigJson("registry1.example.com", "user1", "pass1")
-			pullSecret1Key := types.NamespacedName{Name: "pull-secret-comp1", Namespace: testNamespace}
-			createDockerConfigSecret(pullSecret1Key, pullSecret1Data)
+		It("should create an application pull secret with 1 secret because other secret isn't SecretTypeDockerConfigJson and link it to namespace SA", func() {
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			pullSecret1Data := generateDockerConfigJson(registrySecret1, "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data, true)
 
-			pullSecret2Data := generateDockerConfigJson("registry2.example.com", "user2", "pass2")
-			pullSecret2Key := types.NamespacedName{Name: "pull-secret-comp2", Namespace: testNamespace}
-			createDockerConfigSecret(pullSecret2Key, pullSecret2Data)
+			pullSecret2Data := generateDockerConfigJson(registrySecret2, "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, false)
 
+			// will trigger application controller and create empty secret
+			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
 			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
 			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
-			application := getApplication(applicationKey)
-			component1.OwnerReferences = []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Application", Name: application.Name, UID: application.UID}}
-			component2.OwnerReferences = []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Application", Name: application.Name, UID: application.UID}}
+
+			// wait until empty secret is linked to namespace SA
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
+				}
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			// delete application SA and empty secret as it will be created on next reconcile
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: appSecretTestNamespace})
+			deleteSecret(namespacePullSecretName)
+			// recreate empty SA
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+
+			// set component's owner to application
+			component1.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Application",
+				Name:       application.Name,
+				UID:        application.UID,
+			}}
+			component2.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Application",
+				Name:       application.Name,
+				UID:        application.UID,
+			}}
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
 
-			ir1 := createImageRepository(imageRepositoryConfig{
-				ResourceKey:     &imageRepository1Key,
-				Finalizers:      []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component1.Name, UID: component1.UID}},
-			})
-			ir1.Status.Credentials.PullSecretName = pullSecret1Key.Name
-			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+			// create image repository with finalizer so it won't try to provision repo
+			// also without component & application labels so controller won't try any secrets linking
+			imageConfig1 := imageRepositoryConfig{
+				ResourceKey: &imageRepository1Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component1.Name,
+					UID:        component1.UID,
+				}},
+			}
+			imageConfig2 := imageRepositoryConfig{
+				ResourceKey: &imageRepository2Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component2.Name,
+					UID:        component2.UID,
+				}},
+			}
+			ir1 := createImageRepository(imageConfig1)
+			ir2 := createImageRepository(imageConfig2)
 
-			ir2 := createImageRepository(imageRepositoryConfig{
-				ResourceKey:     &imageRepository2Key,
-				Finalizers:      []string{ImageRepositoryFinalizer},
-				OwnerReferences: []metav1.OwnerReference{{APIVersion: "appstudio.redhat.com/v1alpha1", Kind: "Component", Name: component2.Name, UID: component2.UID}},
-			})
-			ir2.Status.Credentials.PullSecretName = pullSecret2Key.Name
+			// set image repository state to failed so controller will just stop
+			// set also pull & push secret
+			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir1.Status.Credentials.PullSecretName = pullSecret1
+			ir1.Status.Credentials.PushSecretName = pushSecret1
+			ir2.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir2.Status.Credentials.PullSecretName = pullSecret2
+			ir2.Status.Credentials.PushSecretName = pushSecret2
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
 			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
 
-			// Trigger initial reconciliation
-			application.Spec.DisplayName = "initial-reconcile-delete"
-			Expect(k8sClient.Update(ctx, application)).To(Succeed())
-
-			// Wait for aggregated secret to be created with both entries
-			aggregatedSecret := &corev1.Secret{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
-				if err != nil {
-					return false
-				}
-				aggregatedSecretDockerConfigJson := string(aggregatedSecret.Data[corev1.DockerConfigJsonKey])
-
-				var decodedAggregated dockerConfigJson
-				Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
-				return len(decodedAggregated.Auths) == 2 &&
-					decodedAggregated.Auths["registry1.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user1:pass1")) &&
-					decodedAggregated.Auths["registry2.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user2:pass2"))
-			}, timeout, interval).Should(BeTrue(), "Expected aggregated secret to have both initial entries")
-
-			// Delete one of the individual secrets
-			deleteSecret(pullSecret1Key)
+			// set image repository component & application labels
+			ir1.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component1.Name,
+			}
+			ir2.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component2.Name,
+			}
+			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
 
 			// Trigger reconciliation by updating the application
-			application.Spec.DisplayName = "delete-reconcile"
+			application.Spec.DisplayName = "updated-name"
 			Expect(k8sClient.Update(ctx, application)).To(Succeed())
 
-			// Assert aggregated secret no longer contains the deleted entry
+			// wait until empty secret is linked to namespace SA
 			Eventually(func() bool {
-				currentAggregatedSecret := &corev1.Secret{}
-				err := k8sClient.Get(ctx, aggregatedPullSecretName, currentAggregatedSecret)
-				if err != nil {
-					return false
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
 				}
-				aggregatedSecretDockerConfigJson := string(currentAggregatedSecret.Data[corev1.DockerConfigJsonKey])
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 
-				var decodedAggregated dockerConfigJson
-				Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
-				// Should only have one entry left (registry2.example.com)
-				_, registry1Exists := decodedAggregated.Auths["registry1.example.com"]
-				return len(decodedAggregated.Auths) == 1 &&
-					decodedAggregated.Auths["registry2.example.com"].Auth == base64.StdEncoding.EncodeToString([]byte("user2:pass2")) &&
-					!registry1Exists
-			}, timeout, interval).Should(BeTrue(), "Expected aggregated pull secret to remove deleted entry")
+			applicationSecret := getSecret(namespacePullSecretName)
 
-			// Ensure SA still links the same aggregated secret
-			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
+			Expect(applicationSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(applicationSecret.OwnerReferences).To(HaveLen(1))
+			Expect(applicationSecret.OwnerReferences[0].Name).To(Equal(applicationKey.Name))
+			Expect(applicationSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
+
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+
+			Expect(decodedSecret.Auths).To(HaveLen(1))
+			Expect(decodedSecret.Auths).To(HaveKey(registrySecret1))
+			Expect(decodedSecret.Auths[registrySecret1].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte(authSecret1))))
+
+			konfluxSA := getServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
 			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
-			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(namespacePullSecretName.Name))
+			Expect(konfluxSA.Secrets).To(HaveLen(1))
+			Expect(konfluxSA.Secrets[0].Name).To(Equal(namespacePullSecretName.Name))
 		})
 
-		It("should handle empty list of individual secrets gracefully", func() {
-			// Trigger reconciliation by updating the application
-			application := getApplication(applicationKey)
-			application.Spec.DisplayName = "empty-reconcile"
-			Expect(k8sClient.Update(ctx, application)).To(Succeed())
-
-			// Assert aggregated secret is created, but its data is empty
-			aggregatedSecret := &corev1.Secret{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, aggregatedPullSecretName, aggregatedSecret)
-			}, timeout, interval).Should(Succeed(), "Expected aggregated pull secret to be created")
-
-			Expect(aggregatedSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
-			Expect(aggregatedSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
-
-			aggregatedSecretDockerConfigJson := string(aggregatedSecret.Data[corev1.DockerConfigJsonKey])
-
-			var decodedAggregated dockerConfigJson
-			Expect(json.Unmarshal([]byte(aggregatedSecretDockerConfigJson), &decodedAggregated)).To(Succeed())
-			Expect(decodedAggregated.Auths).To(BeEmpty())
-
-			// Assert 'konflux-integration-runner' SA links the empty aggregated secret
-			konfluxSA := getServiceAccount(testNamespace, KonfluxIntegrationRunnerSAName)
-			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
-			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(aggregatedPullSecretName.Name))
-		})
 	})
 })

--- a/internal/controller/component_image_controller_test.go
+++ b/internal/controller/component_image_controller_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Component image controller", func() {
 		}
 		var applicationKey = types.NamespacedName{Name: defaultComponentApplication, Namespace: imageTestNamespace}
 		var componentSaName = getComponentSaName(resourceImageProvisionKey.Name)
-		var applicationSaName = getApplicationSaName(defaultComponentApplication)
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
@@ -61,6 +60,7 @@ var _ = Describe("Component image controller", func() {
 		It("should prepare environment", func() {
 			createServiceAccount(imageTestNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(imageTestNamespace, componentSaName)
+			createServiceAccount(imageTestNamespace, KonfluxIntegrationRunnerSAName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {
@@ -139,7 +139,7 @@ var _ = Describe("Component image controller", func() {
 			deleteImageRepository(imageRepositoryName)
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: imageTestNamespace})
 			deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: imageTestNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: imageTestNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: imageTestNamespace})
 		})
 	})
 
@@ -147,7 +147,6 @@ var _ = Describe("Component image controller", func() {
 		var resourceImageErrorKey = types.NamespacedName{Name: defaultComponentName + "-imageerrors", Namespace: imageTestNamespace}
 		var applicationKey = types.NamespacedName{Name: defaultComponentApplication, Namespace: imageTestNamespace}
 		var componentSaName = getComponentSaName(resourceImageErrorKey.Name)
-		var applicationSaName = getApplicationSaName(defaultComponentApplication)
 
 		It("should prepare environment", func() {
 			deleteComponent(resourceImageErrorKey)
@@ -156,6 +155,7 @@ var _ = Describe("Component image controller", func() {
 
 			createServiceAccount(imageTestNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(imageTestNamespace, componentSaName)
+			createServiceAccount(imageTestNamespace, KonfluxIntegrationRunnerSAName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {
@@ -274,7 +274,7 @@ var _ = Describe("Component image controller", func() {
 			deleteApplication(applicationKey)
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: imageTestNamespace})
 			deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: imageTestNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: imageTestNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: imageTestNamespace})
 		})
 	})
 })

--- a/internal/controller/component_image_controller_test.go
+++ b/internal/controller/component_image_controller_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Component image controller", func() {
 		It("should prepare environment", func() {
 			createServiceAccount(imageTestNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(imageTestNamespace, componentSaName)
-			createServiceAccount(imageTestNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(imageTestNamespace, NamespaceServiceAccountName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {
@@ -155,7 +155,7 @@ var _ = Describe("Component image controller", func() {
 
 			createServiceAccount(imageTestNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(imageTestNamespace, componentSaName)
-			createServiceAccount(imageTestNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(imageTestNamespace, NamespaceServiceAccountName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {

--- a/internal/controller/imagerepository_controller_service_account.go
+++ b/internal/controller/imagerepository_controller_service_account.go
@@ -237,9 +237,9 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 	log := ctrllog.FromContext(ctx)
 
 	componentSaName := getComponentSaName(imageRepository.Labels[ComponentNameLabelName])
-	applicationSaName := getApplicationSaName(imageRepository.Labels[ApplicationNameLabelName])
 	pushSecretName := imageRepository.Status.Credentials.PushSecretName
-	pullSecretName := imageRepository.Status.Credentials.PullSecretName
+	applicationName := imageRepository.Labels[ApplicationNameLabelName]
+	applicationPullSecretName := getApplicationPullSecretName(applicationName)
 
 	// link secret to service account if isn't linked already
 	if err := r.linkSecretToServiceAccount(ctx, buildPipelineServiceAccountName, pushSecretName, imageRepository.Namespace, false); err != nil {
@@ -267,14 +267,14 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 		}
 
 		// link secret to service account if isn't linked already
-		if err := r.linkSecretToServiceAccount(ctx, applicationSaName, pullSecretName, imageRepository.Namespace, true); err != nil {
-			log.Error(err, "failed to link secret to service account", "saName", applicationSaName, "SecretName", pullSecretName, l.Action, l.ActionUpdate)
+		if err := r.linkSecretToServiceAccount(ctx, NamespaceServiceAccountName, applicationPullSecretName, imageRepository.Namespace, true); err != nil {
+			log.Error(err, "failed to link secret to service account", "saName", NamespaceServiceAccountName, "SecretName", applicationPullSecretName, l.Action, l.ActionUpdate)
 			return err
 		}
 
 		// clean duplicate secret links
-		if err := r.cleanUpSecretInServiceAccount(ctx, applicationSaName, pullSecretName, imageRepository.Namespace, true); err != nil {
-			log.Error(err, "failed to clean up secret in service account", "saName", applicationSaName, "SecretName", pullSecretName, l.Action, l.ActionUpdate)
+		if err := r.cleanUpSecretInServiceAccount(ctx, NamespaceServiceAccountName, applicationPullSecretName, imageRepository.Namespace, true); err != nil {
+			log.Error(err, "failed to clean up secret in service account", "saName", NamespaceServiceAccountName, "SecretName", applicationPullSecretName, l.Action, l.ActionUpdate)
 			return err
 		}
 	}

--- a/internal/controller/imagerepository_controller_test.go
+++ b/internal/controller/imagerepository_controller_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Image repository controller", func() {
 			expectedImage = fmt.Sprintf("quay.io/%s/%s", quay.TestQuayOrg, expectedImageName)
 			expectedRobotAccountPrefix = strings.ReplaceAll(strings.ReplaceAll(expectedImageName, "-", "_"), "/", "_")
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 		})
 
 		It("should provision image repository", func() {
@@ -317,7 +317,7 @@ var _ = Describe("Image repository controller", func() {
 			Expect(sa.ImagePullSecrets).To(HaveLen(0))
 
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: defaultNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: defaultNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: defaultNamespace})
 
 		})
 	})
@@ -336,7 +336,7 @@ var _ = Describe("Image repository controller", func() {
 			expectedImage = fmt.Sprintf("quay.io/%s/%s", quay.TestQuayOrg, expectedImageName)
 			expectedRobotAccountPrefix = strings.ReplaceAll(strings.ReplaceAll(expectedImageName, "-", "_"), "/", "_")
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 
 			// add push secret to SA
 			sa := getServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
@@ -476,7 +476,7 @@ var _ = Describe("Image repository controller", func() {
 			Expect(sa.ImagePullSecrets).To(HaveLen(0))
 
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: defaultNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: defaultNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: defaultNamespace})
 
 		})
 	})
@@ -507,7 +507,7 @@ var _ = Describe("Image repository controller", func() {
 
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(defaultNamespace, componentSaName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {
@@ -914,9 +914,6 @@ var _ = Describe("Image repository controller", func() {
 			Expect(k8sClient.Update(ctx, &pipelineSa)).To(Succeed())
 
 			applicationSa := getServiceAccount(defaultNamespace, NamespaceServiceAccountName)
-			applicationSa.Secrets = []corev1.ObjectReference{{Name: pullSecretName}, {Name: pullSecretName}}
-			applicationSa.ImagePullSecrets = []corev1.LocalObjectReference{{Name: pullSecretName}, {Name: pullSecretName}}
-			Expect(k8sClient.Update(ctx, &applicationSa)).To(Succeed())
 
 			componentSa := getServiceAccount(defaultNamespace, componentSaName)
 			componentSa.Secrets = []corev1.ObjectReference{{Name: pushSecretName}, {Name: pushSecretName}}
@@ -981,7 +978,9 @@ var _ = Describe("Image repository controller", func() {
 
 			applicationSa := getServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 			Expect(applicationSa.Secrets).To(HaveLen(1))
-			Expect(applicationSa.ImagePullSecrets).To(HaveLen(0))
+			Expect(applicationSa.ImagePullSecrets).To(HaveLen(1))
+
+			// TODO, check content of the app pull secret
 
 			componentSa := getServiceAccount(defaultNamespace, componentSaName)
 			Expect(componentSa.Secrets).To(HaveLen(0))
@@ -1006,7 +1005,7 @@ var _ = Describe("Image repository controller", func() {
 			expectedImage = fmt.Sprintf("quay.io/%s/%s", quay.TestQuayOrg, expectedImageName)
 			expectedRobotAccountPrefix = strings.ReplaceAll(strings.ReplaceAll(expectedImageName, "-", "_"), "/", "_")
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 
 		})
 
@@ -1215,7 +1214,7 @@ var _ = Describe("Image repository controller", func() {
 
 		It("should clean environment", func() {
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: defaultNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: defaultNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: defaultNamespace})
 
 			deleteImageRepository(resourceKey)
 		})
@@ -1231,7 +1230,7 @@ var _ = Describe("Image repository controller", func() {
 
 		It("should prepare environment", func() {
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 
 		})
 
@@ -1553,7 +1552,7 @@ var _ = Describe("Image repository controller", func() {
 
 		It("should clean environment", func() {
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: defaultNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: defaultNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: defaultNamespace})
 		})
 	})
 
@@ -1567,7 +1566,7 @@ var _ = Describe("Image repository controller", func() {
 
 		It("should prepare environment", func() {
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 
 		})
 
@@ -1619,7 +1618,7 @@ var _ = Describe("Image repository controller", func() {
 
 		It("should clean environment", func() {
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: defaultNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: defaultNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: defaultNamespace})
 
 		})
 	})
@@ -1639,7 +1638,7 @@ var _ = Describe("Image repository controller", func() {
 			expectedRobotAccountPrefix = strings.ReplaceAll(strings.ReplaceAll(expectedImageName, "-", "_"), "/", "_")
 
 			createServiceAccount(defaultNamespace, buildPipelineServiceAccountName)
-			createServiceAccount(defaultNamespace, KonfluxIntegrationRunnerSAName)
+			createServiceAccount(defaultNamespace, NamespaceServiceAccountName)
 
 		})
 
@@ -1742,7 +1741,7 @@ var _ = Describe("Image repository controller", func() {
 
 		It("should clean environment", func() {
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: defaultNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: KonfluxIntegrationRunnerSAName, Namespace: defaultNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: defaultNamespace})
 
 		})
 	})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -127,7 +127,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&ApplicationPullServiceAccountCreator{
+	err = (&ApplicationPullSecretCreator{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)


### PR DESCRIPTION
Previously, we had a SA for each application. Now we will have only pull secret for application that will be linked to SA
"konflux-integration-runner" that will be in each namespace.

The new pull secret for application is an aggregated secret, that contains records for each image repository.

[STONEBLD-3611](https://issues.redhat.com//browse/STONEBLD-3611)


Assisted-by: Gemini 2.5 Pro