### PR TITLE
Create application pull secret and link it to integration SA

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,7 +224,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ApplicationPullServiceAccountCreator{
+	if err = (&controllers.ApplicationPullSecretCreator{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,14 +36,24 @@ import (
 	appstudioredhatcomv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 )
 
-// ApplicationPullServiceAccountCreator reconciles a Application object
-type ApplicationPullServiceAccountCreator struct {
+const NamespaceServiceAccountName = "konflux-integration-runner"
+
+// dockerConfigJson represents the structure of a .dockerconfigjson secret
+type dockerConfigJson struct {
+	Auths map[string]dockerConfigAuth `json:"auths"`
+}
+type dockerConfigAuth struct {
+	Auth string `json:"auth"`
+}
+
+// ApplicationPullSecretCreator reconciles an Application object
+type ApplicationPullSecretCreator struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ApplicationPullServiceAccountCreator) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ApplicationPullSecretCreator) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appstudioredhatcomv1alpha1.Application{}).
 		Complete(r)
@@ -53,7 +64,7 @@ func (r *ApplicationPullServiceAccountCreator) SetupWithManager(mgr ctrl.Manager
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
-func (r *ApplicationPullServiceAccountCreator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ApplicationPullSecretCreator) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx).WithName("Application")
 	ctx = ctrllog.IntoContext(ctx, log)
 
@@ -74,45 +85,41 @@ func (r *ApplicationPullServiceAccountCreator) Reconcile(ctx context.Context, re
 		return ctrl.Result{}, nil
 	}
 
-	// fetch application SA
-	applicationSaName := getApplicationSaName(application.Name)
-	applicationServiceAccount := &corev1.ServiceAccount{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: applicationSaName, Namespace: application.Namespace}, applicationServiceAccount)
-	if err == nil {
-		// service account already exists nothing to do
-		return ctrl.Result{}, nil
-	}
-	if !errors.IsNotFound(err) {
-		log.Error(err, "failed to read application service account", "serviceAccountName", applicationSaName, "namespace", application.Namespace, l.Action, l.ActionView)
-		return ctrl.Result{}, err
-	}
-
-	componentIds, err := r.getComponentIdsForApplication(ctx, application.UID, application.Namespace)
+	applicationPullSecretName := getApplicationPullSecretName(application.Name)
+	applicationPullSecretExists, err := r.doesApplicationPullSecretExist(ctx, applicationPullSecretName, application)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if !applicationPullSecretExists {
+		componentIds, err := r.getComponentIdsForApplication(ctx, application.UID, application.Namespace)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	pullSecretNames, err := r.getImageRepositoryPullSecretNamesForComponents(ctx, componentIds, application.Namespace)
-	if err != nil {
-		return ctrl.Result{}, err
+		pullSecretNames, err := r.getImageRepositoryPullSecretNamesForComponents(ctx, componentIds, application.Namespace)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if err := r.createApplicationPullSecret(ctx, applicationPullSecretName, application, pullSecretNames); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
-	// service account doesn't exist we will have to create it
-	err = r.createApplicationServiceAccount(ctx, applicationSaName, application, pullSecretNames)
-	if err != nil {
+	if err := r.updateServiceAccountWithApplicationPullSecret(ctx, applicationPullSecretName, application.Namespace); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-// getApplicationSaName returns name of application SA
-func getApplicationSaName(applicationName string) string {
+// getApplicationPullSecretName returns name for the application pull dockerconfigjson secret
+func getApplicationPullSecretName(applicationName string) string {
 	return fmt.Sprintf("%s-pull", applicationName)
 }
 
 // getComponentIdsForApplication returns components id for all components owned by the application
-func (r *ApplicationPullServiceAccountCreator) getComponentIdsForApplication(ctx context.Context, applicationId types.UID, namespace string) ([]types.UID, error) {
+func (r *ApplicationPullSecretCreator) getComponentIdsForApplication(ctx context.Context, applicationId types.UID, namespace string) ([]types.UID, error) {
 	log := ctrllog.FromContext(ctx)
 	componentsList := &appstudioredhatcomv1alpha1.ComponentList{}
 	if err := r.Client.List(ctx, componentsList, &client.ListOptions{Namespace: namespace}); err != nil {
@@ -134,7 +141,7 @@ func (r *ApplicationPullServiceAccountCreator) getComponentIdsForApplication(ctx
 }
 
 // getImageRepositoryPullSecretNamesForComponents returns pull secret names from imagerepositories owned by provided components
-func (r *ApplicationPullServiceAccountCreator) getImageRepositoryPullSecretNamesForComponents(ctx context.Context, componentIds []types.UID, namespaceName string) ([]string, error) {
+func (r *ApplicationPullSecretCreator) getImageRepositoryPullSecretNamesForComponents(ctx context.Context, componentIds []types.UID, namespaceName string) ([]string, error) {
 	log := ctrllog.FromContext(ctx)
 	imageRepositoryList := &imagerepositoryv1alpha1.ImageRepositoryList{}
 	if err := r.Client.List(ctx, imageRepositoryList, &client.ListOptions{Namespace: namespaceName}); err != nil {
@@ -163,49 +170,159 @@ func (r *ApplicationPullServiceAccountCreator) getImageRepositoryPullSecretNames
 	return pullSecretNames, nil
 }
 
-// createApplicationServiceAccount creates application service account with provided pull secrets
-func (r *ApplicationPullServiceAccountCreator) createApplicationServiceAccount(ctx context.Context, serviceAccountName string, application *appstudioredhatcomv1alpha1.Application, pullSecretNames []string) error {
-	log := ctrllog.FromContext(ctx).WithValues("serviceAccountName", serviceAccountName, "namespace", application.Namespace)
+// createApplicationPullSecret creates or updates a single kubernetes.io/dockerconfigjson secret
+// by combining data from individual pull secrets.
+func (r *ApplicationPullSecretCreator) createApplicationPullSecret(ctx context.Context, applicationPullSecretName string, application *appstudioredhatcomv1alpha1.Application, individualSecretNames []string) error {
+	log := ctrllog.FromContext(ctx)
 
-	applicationServiceAccount := &corev1.ServiceAccount{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: application.Namespace}, applicationServiceAccount)
+	log.Info("Creating application pull secret", "secretName", applicationPullSecretName)
+	combinedAuths := dockerConfigJson{Auths: map[string]dockerConfigAuth{}}
+
+	secretList := &corev1.SecretList{}
+	if err := r.Client.List(ctx, secretList, &client.ListOptions{Namespace: application.Namespace}); err != nil {
+		log.Error(err, "failed to list secrets", l.Action, l.ActionView)
+		return err
+	}
+
+	for _, secret := range secretList.Items {
+		shouldProcess := false
+		for _, name := range individualSecretNames {
+			if secret.Name == name {
+				shouldProcess = true
+				break
+			}
+		}
+		if !shouldProcess {
+			continue
+		}
+
+		// Only process secrets of type kubernetes.io/dockerconfigjson
+		if secret.Type != corev1.SecretTypeDockerConfigJson {
+			continue
+		}
+
+		// Secret missing .dockerconfigjson key
+		dockerConfigDataBytes, ok := secret.Data[corev1.DockerConfigJsonKey]
+		if !ok {
+			continue
+		}
+
+		var dcj dockerConfigJson
+		if err := json.Unmarshal(dockerConfigDataBytes, &dcj); err != nil {
+			log.Error(err, "failed to unmarshal .dockerconfigjson data from secret", "secretName", secret.Name)
+			continue
+		}
+
+		for registry, authEntry := range dcj.Auths {
+			combinedAuths.Auths[registry] = authEntry
+		}
+	}
+
+	// Marshal combined auths back into .dockerconfigjson format
+	combinedDockerConfig := dockerConfigJson{Auths: combinedAuths.Auths}
+	marshaledData, err := json.Marshal(combinedDockerConfig)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			log.Error(err, "failed to read application service account", l.Action, l.ActionView)
+		log.Error(err, "failed to marshal combined docker config json")
+		return err
+	}
+
+	// Create the application pull secret
+	applicationPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      applicationPullSecretName,
+			Namespace: application.Namespace,
+			Labels: map[string]string{
+				InternalSecretLabelName: "true",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: marshaledData,
+		},
+	}
+
+	// Set pull secret ownership to application
+	if err := controllerutil.SetOwnerReference(application, applicationPullSecret, r.Scheme); err != nil {
+		log.Error(err, "failed to set application as owner of application pull secret", "applicationName", application.Name)
+		return err
+	}
+
+	if err := r.Client.Create(ctx, applicationPullSecret); err != nil {
+		log.Error(err, "failed to create application pull secret", "secretName", applicationPullSecretName, l.Action, l.ActionAdd)
+		return err
+	}
+
+	log.Info("Application pull secret created successfully", "secretName", applicationPullSecretName)
+	return nil
+}
+
+// udateServiceAccountWithApplicationPullSecret updates the ServiceAccount to include
+// the application pull secret as an imagePullSecret and as a Secret
+func (r *ApplicationPullSecretCreator) updateServiceAccountWithApplicationPullSecret(ctx context.Context, applicationPullSecretName string, namespace string) error {
+	log := ctrllog.FromContext(ctx)
+
+	// fetch namespace SA
+	namespaceServiceAccount := &corev1.ServiceAccount{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: namespace}, namespaceServiceAccount); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Namespace ServiceAccount not found", "serviceAccountName", NamespaceServiceAccountName, "namespace", namespace)
+			return nil
+		}
+		log.Error(err, "failed to read namespace ServiceAccount", "serviceAccountName", NamespaceServiceAccountName, "namespace", namespace, l.Action, l.ActionView)
+		return err
+	}
+
+	// Check and update Secrets
+	secretLinked := false
+	shouldUpdateServiceAccount := false
+	for _, secret := range namespaceServiceAccount.Secrets {
+		if secret.Name == applicationPullSecretName {
+			secretLinked = true
+			break
+		}
+	}
+	if !secretLinked {
+		namespaceServiceAccount.Secrets = append(namespaceServiceAccount.Secrets, corev1.ObjectReference{Name: applicationPullSecretName})
+		shouldUpdateServiceAccount = true
+	}
+
+	// Check and update imagePullSecrets
+	secretLinked = false
+	for _, pullSecret := range namespaceServiceAccount.ImagePullSecrets {
+		if pullSecret.Name == applicationPullSecretName {
+			secretLinked = true
+			break
+		}
+	}
+
+	if !secretLinked {
+		namespaceServiceAccount.ImagePullSecrets = append(namespaceServiceAccount.ImagePullSecrets, corev1.LocalObjectReference{Name: applicationPullSecretName})
+		shouldUpdateServiceAccount = true
+	}
+
+	if shouldUpdateServiceAccount {
+		if err := r.Client.Update(ctx, namespaceServiceAccount); err != nil {
+			log.Error(err, "failed to update Service Account with application pull secret", l.Action, l.ActionUpdate)
 			return err
 		}
-	} else {
-		return nil
+		log.Info("Service Account updated successfully with application pull secret.", "secretName", applicationPullSecretName)
 	}
 
-	// Create service account for application
-	secretsReferences := []corev1.ObjectReference{}
-	imagePullSecretsReferences := []corev1.LocalObjectReference{}
-	for _, secretName := range pullSecretNames {
-		secretsReferences = append(secretsReferences, corev1.ObjectReference{Name: secretName})
-		imagePullSecretsReferences = append(imagePullSecretsReferences, corev1.LocalObjectReference{Name: secretName})
-	}
-
-	applicationSA := corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceAccountName,
-			Namespace: application.Namespace,
-		},
-		Secrets:          secretsReferences,
-		ImagePullSecrets: imagePullSecretsReferences,
-	}
-
-	// set serviceAccount ownership to application
-	if err := controllerutil.SetOwnerReference(application, &applicationSA, r.Scheme); err != nil {
-		log.Error(err, "failed to set application as owner of SA", "applicationName", application.Name)
-		return err
-	}
-
-	if err := r.Client.Create(ctx, &applicationSA); err != nil {
-		log.Error(err, "failed to create service account", "serviceAccountName", l.Action, l.ActionAdd)
-		return err
-	}
-
-	log.Info("application service account created", "SecretNames", pullSecretNames)
 	return nil
+}
+
+func (r *ApplicationPullSecretCreator) doesApplicationPullSecretExist(ctx context.Context, applicationPullSecretName string, application *appstudioredhatcomv1alpha1.Application) (bool, error) {
+	log := ctrllog.FromContext(ctx)
+
+	applicationPullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: applicationPullSecretName, Namespace: application.Namespace}, applicationPullSecret); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		log.Error(err, "failed to get application pull secret", "secretName", applicationPullSecretName, l.Action, l.ActionView)
+		return false, err
+	}
+
+	return true, nil
 }

--- a/internal/controller/application_controller_test.go
+++ b/internal/controller/application_controller_test.go
@@ -16,8 +16,12 @@ limitations under the License.
 package controllers
 
 import (
+	"encoding/base64"
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,88 +30,126 @@ import (
 )
 
 var _ = Describe("Application controller", func() {
-	Context("Application service account doesn't exist", func() {
-		var appSaTestNamespace = "application-sa-namespace-test"
-		var applicationKey = types.NamespacedName{Name: "application-sa-test", Namespace: appSaTestNamespace}
-		var component1Key = types.NamespacedName{Name: "component1-test", Namespace: appSaTestNamespace}
-		var component2Key = types.NamespacedName{Name: "component2-test", Namespace: appSaTestNamespace}
-		var imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: appSaTestNamespace}
-		var imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: appSaTestNamespace}
-		var pullSecret1 = "pull-secret1"
-		var pushSecret1 = "push-secret1"
-		var pullSecret2 = "pull-secret2"
-		var pushSecret2 = "push-secret2"
-		var applicationSaName = getApplicationSaName(applicationKey.Name)
+	var appSecretTestNamespace = "application-secret-namespace-test"
+	var applicationKey = types.NamespacedName{Name: "application-test", Namespace: appSecretTestNamespace}
+	var component1Key = types.NamespacedName{Name: "component1-test", Namespace: appSecretTestNamespace}
+	var component2Key = types.NamespacedName{Name: "component2-test", Namespace: appSecretTestNamespace}
+	var imageRepository1Key = types.NamespacedName{Name: "ir1-test", Namespace: appSecretTestNamespace}
+	var imageRepository2Key = types.NamespacedName{Name: "ir2-test", Namespace: appSecretTestNamespace}
+	var namespacePullSecretName = types.NamespacedName{Name: getApplicationPullSecretName(applicationKey.Name), Namespace: appSecretTestNamespace}
+	var pullSecret1 = "pull-secret1"
+	var pushSecret1 = "push-secret1"
+	var pullSecret2 = "pull-secret2"
+	var pushSecret2 = "push-secret2"
+	var authSecret1 = "user1:pass1"
+	var authSecret2 = "user2:pass2"
+	var registrySecret1 = "registry1.example.com"
+	var registrySecret2 = "registry2.example.com"
 
+	Context("Create application secret and link it to Namespace ServiceAccount when it exists", func() {
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
 		})
 
 		AfterEach(func() {
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: appSecretTestNamespace})
+			deleteSecret(namespacePullSecretName)
 			deleteImageRepository(imageRepository2Key)
 			deleteImageRepository(imageRepository1Key)
 			deleteComponent(component1Key)
 			deleteComponent(component2Key)
 			deleteApplication(applicationKey)
+			deleteSecret(types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace})
+			deleteSecret(types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace})
 		})
 
 		It("should prepare environment", func() {
-			createNamespace(appSaTestNamespace)
+			createNamespace(appSecretTestNamespace)
 		})
 
-		It("application SA will be created with no secrets because no components are owned by application", func() {
+		It("should create empty application pull secret and without link it to not existing namespace SA, because no components are owned by application", func() {
 			createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
 			createApplication(applicationConfig{ApplicationKey: applicationKey})
 
-			// wait until application SA is created with no secrets
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-				}
-				return saCount == 1 && secretsCount == 0
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+			// wait until application secret is created
+			applicationSecret := waitSecretExist(namespacePullSecretName)
 
-			saList := getServiceAccountList(appSaTestNamespace)
-			Expect(len(saList)).Should(Equal(1))
-			Expect(saList[0].Name).Should(Equal(applicationSaName))
-			Expect(len(saList[0].Secrets)).Should(Equal(0))
-			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(0))
-			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
-			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(applicationKey.Name))
+			// verify that namespace SA doesn't exist
+			saList := getServiceAccountList(appSecretTestNamespace)
+			Expect(len(saList)).Should(Equal(0))
+
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+			Expect(len(decodedSecret.Auths)).Should(Equal(0))
 		})
 
-		It("application SA will be created with no secrets because component owned by application doesn't own any image repository", func() {
-			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+		It("should create empty application pull secret and link it to namespace SA, because no components are owned by application", func() {
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			createApplication(applicationConfig{ApplicationKey: applicationKey})
 
-			// create image repository with finalizer so it won't try to provision repo
-			imageConfig1 := imageRepositoryConfig{
-				ResourceKey: &imageRepository1Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
-			}
-			ir1 := createImageRepository(imageConfig1)
-
-			// set image repository state to failed so controller will just stop
-			// set also pull & push secret
-			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
-			ir1.Status.Credentials.PullSecretName = pullSecret1
-			ir1.Status.Credentials.PushSecretName = pushSecret1
-			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
-
-			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
-
-			// wait until application SA is created with no secrets
+			// wait until empty secret is linked to namespace SA
 			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
+				saList := getServiceAccountList(appSecretTestNamespace)
 				saCount := len(saList)
 				secretsCount := 0
+				pullSecretsCount := 0
 				if saCount > 0 {
 					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
 				}
-				return saCount == 1 && secretsCount == 0
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
 			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			saList := getServiceAccountList(appSecretTestNamespace)
+			Expect(len(saList)).Should(Equal(1))
+			Expect(saList[0].Name).Should(Equal(NamespaceServiceAccountName))
+			Expect(len(saList[0].Secrets)).Should(Equal(1))
+			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(1))
+
+			applicationSecret := waitSecretExist(namespacePullSecretName)
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+			Expect(len(decodedSecret.Auths)).Should(Equal(0))
+		})
+
+		It("should create an application pull secret with 2 secrets and link it to namespace SA", func() {
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			pullSecret1Data := generateDockerConfigJson(registrySecret1, "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data, true)
+
+			pullSecret2Data := generateDockerConfigJson(registrySecret2, "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, true)
+
+			// will trigger application controller and create empty secret
+			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
+			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+
+			// wait until empty secret is linked to namespace SA
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
+				}
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			// delete application SA and empty secret as it will be created on next reconcile
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: appSecretTestNamespace})
+			deleteSecret(namespacePullSecretName)
+			// recreate empty SA
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
 
 			// set component's owner to application
 			component1.OwnerReferences = []metav1.OwnerReference{{
@@ -116,38 +158,14 @@ var _ = Describe("Application controller", func() {
 				Name:       application.Name,
 				UID:        application.UID,
 			}}
+			component2.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Application",
+				Name:       application.Name,
+				UID:        application.UID,
+			}}
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
-
-			// delete application service account so it gets created again and with secret
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: appSaTestNamespace})
-
-			// update application to trigger application controller
-			application.Spec.DisplayName = "test-name"
-			Expect(k8sClient.Update(ctx, application)).To(Succeed())
-
-			// wait for application SA to contain secret
-			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
-				saCount := len(saList)
-				secretsCount := 0
-				if saCount > 0 {
-					secretsCount = len(saList[0].Secrets)
-				}
-				return saCount == 1 && secretsCount == 0
-			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
-
-			saList := getServiceAccountList(appSaTestNamespace)
-			Expect(len(saList)).Should(Equal(1))
-			Expect(saList[0].Name).Should(Equal(applicationSaName))
-			Expect(len(saList[0].Secrets)).Should(Equal(0))
-			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(0))
-			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
-			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(applicationKey.Name))
-		})
-
-		It("application SA will be created with secrets for two components owned by application", func() {
-			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
 
 			// create image repository with finalizer so it won't try to provision repo
 			// also without component & application labels so controller won't try any secrets linking
@@ -197,18 +215,80 @@ var _ = Describe("Application controller", func() {
 			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
 
-			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
+			// Trigger reconciliation by updating the application
+			application.Spec.DisplayName = "updated-name"
+			Expect(k8sClient.Update(ctx, application)).To(Succeed())
 
-			// wait until application SA is created with no secrets
+			// wait until empty secret is linked to namespace SA
 			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
+				saList := getServiceAccountList(appSecretTestNamespace)
 				saCount := len(saList)
 				secretsCount := 0
+				pullSecretsCount := 0
 				if saCount > 0 {
 					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
 				}
-				return saCount == 1 && secretsCount == 0
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
 			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			applicationSecret := waitSecretExist(namespacePullSecretName)
+
+			Expect(applicationSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(applicationSecret.OwnerReferences).To(HaveLen(1))
+			Expect(applicationSecret.OwnerReferences[0].Name).To(Equal(applicationKey.Name))
+			Expect(applicationSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
+
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+
+			Expect(decodedSecret.Auths).To(HaveLen(2))
+			Expect(decodedSecret.Auths).To(HaveKey(registrySecret1))
+			Expect(decodedSecret.Auths[registrySecret1].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte(authSecret1))))
+			Expect(decodedSecret.Auths).To(HaveKey(registrySecret2))
+			Expect(decodedSecret.Auths[registrySecret2].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte(authSecret2))))
+
+			konfluxSA := getServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(namespacePullSecretName.Name))
+			Expect(konfluxSA.Secrets).To(HaveLen(1))
+			Expect(konfluxSA.Secrets[0].Name).To(Equal(namespacePullSecretName.Name))
+		})
+
+		It("should create an application pull secret with 1 secret because other secret isn't SecretTypeDockerConfigJson and link it to namespace SA", func() {
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			pullSecret1Data := generateDockerConfigJson(registrySecret1, "user1", "pass1")
+			pullSecret1Key := types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret1Key, pullSecret1Data, true)
+
+			pullSecret2Data := generateDockerConfigJson(registrySecret2, "user2", "pass2")
+			pullSecret2Key := types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace}
+			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, false)
+
+			// will trigger application controller and create empty secret
+			application := createApplication(applicationConfig{ApplicationKey: applicationKey})
+			component1 := createComponent(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			component2 := createComponent(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+
+			// wait until empty secret is linked to namespace SA
+			Eventually(func() bool {
+				saList := getServiceAccountList(appSecretTestNamespace)
+				saCount := len(saList)
+				secretsCount := 0
+				pullSecretsCount := 0
+				if saCount > 0 {
+					secretsCount = len(saList[0].Secrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
+				}
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
+			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+
+			// delete application SA and empty secret as it will be created on next reconcile
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: appSecretTestNamespace})
+			deleteSecret(namespacePullSecretName)
+			// recreate empty SA
+			createServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
 
 			// set component's owner to application
 			component1.OwnerReferences = []metav1.OwnerReference{{
@@ -226,51 +306,92 @@ var _ = Describe("Application controller", func() {
 			Expect(k8sClient.Update(ctx, component1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, component2)).To(Succeed())
 
-			// delete application service account so it gets created again and with secret
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: appSaTestNamespace})
+			// create image repository with finalizer so it won't try to provision repo
+			// also without component & application labels so controller won't try any secrets linking
+			imageConfig1 := imageRepositoryConfig{
+				ResourceKey: &imageRepository1Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component1.Name,
+					UID:        component1.UID,
+				}},
+			}
+			imageConfig2 := imageRepositoryConfig{
+				ResourceKey: &imageRepository2Key,
+				Finalizers:  []string{ImageRepositoryFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Component",
+					Name:       component2.Name,
+					UID:        component2.UID,
+				}},
+			}
+			ir1 := createImageRepository(imageConfig1)
+			ir2 := createImageRepository(imageConfig2)
 
-			// update application to trigger application controller
-			application.Spec.DisplayName = "test-name"
+			// set image repository state to failed so controller will just stop
+			// set also pull & push secret
+			ir1.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir1.Status.Credentials.PullSecretName = pullSecret1
+			ir1.Status.Credentials.PushSecretName = pushSecret1
+			ir2.Status.State = imagerepositoryv1alpha1.ImageRepositoryStateFailed
+			ir2.Status.Credentials.PullSecretName = pullSecret2
+			ir2.Status.Credentials.PushSecretName = pushSecret2
+			Expect(k8sClient.Status().Update(ctx, ir1)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, ir2)).To(Succeed())
+
+			// set image repository component & application labels
+			ir1.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component1.Name,
+			}
+			ir2.Labels = map[string]string{
+				ApplicationNameLabelName: applicationKey.Name,
+				ComponentNameLabelName:   component2.Name,
+			}
+			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
+			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
+
+			// Trigger reconciliation by updating the application
+			application.Spec.DisplayName = "updated-name"
 			Expect(k8sClient.Update(ctx, application)).To(Succeed())
 
-			// wait for application SA to contain secret
+			// wait until empty secret is linked to namespace SA
 			Eventually(func() bool {
-				saList := getServiceAccountList(appSaTestNamespace)
+				saList := getServiceAccountList(appSecretTestNamespace)
 				saCount := len(saList)
 				secretsCount := 0
-				imagePullSecretsCount := 0
+				pullSecretsCount := 0
 				if saCount > 0 {
 					secretsCount = len(saList[0].Secrets)
-					imagePullSecretsCount = len(saList[0].ImagePullSecrets)
+					pullSecretsCount = len(saList[0].ImagePullSecrets)
 				}
-				return saCount == 1 && secretsCount == 2 && imagePullSecretsCount == 2
+				return saCount == 1 && secretsCount == 1 && pullSecretsCount == 1
 			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 
-			saList := getServiceAccountList(appSaTestNamespace)
-			Expect(len(saList)).Should(Equal(1))
-			Expect(saList[0].Name).Should(Equal(applicationSaName))
-			Expect(len(saList[0].Secrets)).Should(Equal(2))
-			Expect(len(saList[0].ImagePullSecrets)).Should(Equal(2))
+			applicationSecret := waitSecretExist(namespacePullSecretName)
 
-			secretCounter := map[string]int{}
-			imagePullSecretCounter := map[string]int{}
-			for _, secret := range saList[0].Secrets {
-				secretCounter[secret.Name]++
-			}
-			for _, secret := range saList[0].ImagePullSecrets {
-				imagePullSecretCounter[secret.Name]++
-			}
+			Expect(applicationSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(applicationSecret.OwnerReferences).To(HaveLen(1))
+			Expect(applicationSecret.OwnerReferences[0].Name).To(Equal(applicationKey.Name))
+			Expect(applicationSecret.Data).To(HaveKey(corev1.DockerConfigJsonKey))
 
-			Expect(secretCounter[pullSecret1]).Should(Equal(1))
-			Expect(secretCounter[pullSecret2]).Should(Equal(1))
-			Expect(imagePullSecretCounter[pullSecret1]).Should(Equal(1))
-			Expect(imagePullSecretCounter[pullSecret2]).Should(Equal(1))
-			Expect(len(saList[0].OwnerReferences)).Should(Equal(1))
-			Expect(saList[0].OwnerReferences[0].Name).Should(Equal(application.Name))
+			applicationSecretDockerConfigJson := string(applicationSecret.Data[corev1.DockerConfigJsonKey])
+			var decodedSecret dockerConfigJson
+			Expect(json.Unmarshal([]byte(applicationSecretDockerConfigJson), &decodedSecret)).To(Succeed())
+
+			Expect(decodedSecret.Auths).To(HaveLen(1))
+			Expect(decodedSecret.Auths).To(HaveKey(registrySecret1))
+			Expect(decodedSecret.Auths[registrySecret1].Auth).To(Equal(base64.StdEncoding.EncodeToString([]byte(authSecret1))))
+
+			konfluxSA := getServiceAccount(appSecretTestNamespace, NamespaceServiceAccountName)
+			Expect(konfluxSA.ImagePullSecrets).To(HaveLen(1))
+			Expect(konfluxSA.ImagePullSecrets[0].Name).To(Equal(namespacePullSecretName.Name))
+			Expect(konfluxSA.Secrets).To(HaveLen(1))
+			Expect(konfluxSA.Secrets[0].Name).To(Equal(namespacePullSecretName.Name))
 		})
 
-		It("should cleanup environment", func() {
-			deleteNamespace(appSaTestNamespace)
-		})
 	})
 })

--- a/internal/controller/component_image_controller_test.go
+++ b/internal/controller/component_image_controller_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Component image controller", func() {
 		}
 		var applicationKey = types.NamespacedName{Name: defaultComponentApplication, Namespace: imageTestNamespace}
 		var componentSaName = getComponentSaName(resourceImageProvisionKey.Name)
-		var applicationSaName = getApplicationSaName(defaultComponentApplication)
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
@@ -61,6 +60,7 @@ var _ = Describe("Component image controller", func() {
 		It("should prepare environment", func() {
 			createServiceAccount(imageTestNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(imageTestNamespace, componentSaName)
+			createServiceAccount(imageTestNamespace, NamespaceServiceAccountName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {
@@ -139,7 +139,7 @@ var _ = Describe("Component image controller", func() {
 			deleteImageRepository(imageRepositoryName)
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: imageTestNamespace})
 			deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: imageTestNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: imageTestNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: imageTestNamespace})
 		})
 	})
 
@@ -147,7 +147,6 @@ var _ = Describe("Component image controller", func() {
 		var resourceImageErrorKey = types.NamespacedName{Name: defaultComponentName + "-imageerrors", Namespace: imageTestNamespace}
 		var applicationKey = types.NamespacedName{Name: defaultComponentApplication, Namespace: imageTestNamespace}
 		var componentSaName = getComponentSaName(resourceImageErrorKey.Name)
-		var applicationSaName = getApplicationSaName(defaultComponentApplication)
 
 		It("should prepare environment", func() {
 			deleteComponent(resourceImageErrorKey)
@@ -156,6 +155,7 @@ var _ = Describe("Component image controller", func() {
 
 			createServiceAccount(imageTestNamespace, buildPipelineServiceAccountName)
 			createServiceAccount(imageTestNamespace, componentSaName)
+			createServiceAccount(imageTestNamespace, NamespaceServiceAccountName)
 
 			// wait for application SA to be created
 			Eventually(func() bool {
@@ -274,7 +274,7 @@ var _ = Describe("Component image controller", func() {
 			deleteApplication(applicationKey)
 			deleteServiceAccount(types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: imageTestNamespace})
 			deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: imageTestNamespace})
-			deleteServiceAccount(types.NamespacedName{Name: applicationSaName, Namespace: imageTestNamespace})
+			deleteServiceAccount(types.NamespacedName{Name: NamespaceServiceAccountName, Namespace: imageTestNamespace})
 		})
 	})
 })

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -134,10 +135,10 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				return ctrl.Result{}, err
 			}
 
-			// unlink secret from application SA
-			applicationSaName := getApplicationSaName(imageRepository.Labels[ApplicationNameLabelName])
-			if err := r.unlinkSecretFromServiceAccount(ctx, applicationSaName, imageRepository.Status.Credentials.PullSecretName, imageRepository.Namespace); err != nil {
-				log.Error(err, "failed to unlink secret from service account", "SaName", applicationSaName, "SecretName", imageRepository.Status.Credentials.PullSecretName, l.Action, l.ActionUpdate)
+			// remove pull secret entry from application pull secret
+			err := r.removePullSecretFromApplicationPullSecret(ctx, imageRepository)
+			if err != nil {
+				log.Error(err, "failed to remove entry from application pull secret", "application", imageRepository.Labels[ApplicationNameLabelName], "secret", imageRepository.Status.Credentials.PullSecretName)
 				return ctrl.Result{}, err
 			}
 
@@ -221,11 +222,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Update component
 	if isComponentLinked(imageRepository) {
-		// link secret to application SA
-		applicationSaName := getApplicationSaName(imageRepository.Labels[ApplicationNameLabelName])
+		// update application pull secret
+		applicationName := imageRepository.Labels[ApplicationNameLabelName]
 		pullSecretName := getSecretName(imageRepository, true)
-		if err := r.linkSecretToServiceAccount(ctx, applicationSaName, pullSecretName, imageRepository.Namespace, true); err != nil {
-			log.Error(err, "failed to link secret to service account", "SaName", applicationSaName, "SecretName", pullSecretName, l.Action, l.ActionUpdate)
+		err := r.addPullSecretAuthToApplicationPullSecret(ctx, applicationName, imageRepository.Namespace, pullSecretName, imageRepository.Status.Image.URL, false)
+		if err != nil {
+			log.Error(err, "failed to update application pull secret with individual pull secret", "application", applicationName, "secret", pullSecretName)
 			return ctrl.Result{}, err
 		}
 
@@ -650,6 +652,17 @@ func (r *ImageRepositoryReconciler) RegenerateImageRepositoryAccessToken(ctx con
 	if err := r.EnsureSecret(ctx, imageRepository, secretName, robotAccount, quayImageURL, isPullOnly); err != nil {
 		return err
 	}
+
+	// update also secret in application secret
+	if isComponentLinked(imageRepository) && isPullOnly {
+		applicationName := imageRepository.Labels[ApplicationNameLabelName]
+		err := r.addPullSecretAuthToApplicationPullSecret(ctx, applicationName, imageRepository.Namespace, secretName, imageRepository.Status.Image.URL, true)
+		if err != nil {
+			log.Error(err, "failed to update application pull secret after individual pull secret change", "application", applicationName, "secret", secretName)
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -767,6 +780,14 @@ func (r *ImageRepositoryReconciler) EnsureSecret(ctx context.Context, imageRepos
 			return err
 		}
 		log.Info("Image repository secret created")
+
+	} else {
+		secret.StringData = generateDockerconfigSecretData(imageURL, robotAccount)
+		if err := r.Client.Update(ctx, secret); err != nil {
+			log.Error(err, "failed to update image repository secret", l.Action, l.ActionUpdate, l.Audit, "true")
+			return err
+		}
+		log.Info("Image repository secret updated")
 	}
 	if !isPull {
 		if err := r.linkSecretToServiceAccount(ctx, buildPipelineServiceAccountName, secretName, imageRepository.Namespace, false); err != nil {
@@ -876,4 +897,240 @@ func (r *ImageRepositoryReconciler) ImageRepositoryForSameUrlExists(ctx context.
 // getComponentSaName returns name of component SA
 func getComponentSaName(componentName string) string {
 	return fmt.Sprintf("%s%s", componentSaNamePrefix, componentName)
+}
+
+// addPullSecretAuthToApplicationPullSecret updates the application pull secret when new image repository pull secret is created
+// or when an existing one is updated.
+func (r *ImageRepositoryReconciler) addPullSecretAuthToApplicationPullSecret(ctx context.Context, applicationName, namespace, pullSecretName, imageURL string, overwrite bool) error {
+	log := ctrllog.FromContext(ctx)
+
+	application := &appstudioredhatcomv1alpha1.Application{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: applicationName, Namespace: namespace}, application); err != nil {
+		log.Error(err, "failed to get Application", "application", applicationName)
+		return err
+	}
+
+	applicationPullSecretName := getApplicationPullSecretName(applicationName)
+	applicationPullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: applicationPullSecretName, Namespace: namespace}, applicationPullSecret); err != nil {
+		log.Error(err, "failed to get application pull secret", "secretName", applicationPullSecretName)
+		return err
+	}
+
+	var existingAuths dockerConfigJson
+	if err := json.Unmarshal(applicationPullSecret.Data[corev1.DockerConfigJsonKey], &existingAuths); err != nil {
+		log.Error(err, "failed to unmarshal existing .dockerconfigjson", "secretName", applicationPullSecretName)
+		return err
+	}
+
+	if !overwrite && imageURL != "" {
+		if _, authAlreadyExists := existingAuths.Auths[imageURL]; authAlreadyExists {
+			return nil
+		}
+	}
+
+	pullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: pullSecretName, Namespace: namespace}, pullSecret); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("individual pull secret doesn't exist, nothing to add to application secret", "secretName", pullSecretName)
+			return nil
+		}
+		log.Error(err, "failed to get individual pull secret", "secretName", pullSecretName)
+		return err
+	}
+	if pullSecret.Type != corev1.SecretTypeDockerConfigJson {
+		log.Info("Skipping secret due to unexpected type", "secretName", pullSecretName, "type", pullSecret.Type)
+		return nil
+	}
+
+	dockerConfigDataBytes, ok := pullSecret.Data[corev1.DockerConfigJsonKey]
+	if !ok {
+		log.Info("Missing .dockerconfigjson key", "secretName", pullSecretName)
+		return nil
+	}
+
+	var newAuths dockerConfigJson
+	if err := json.Unmarshal(dockerConfigDataBytes, &newAuths); err != nil {
+		log.Error(err, "failed to unmarshal .dockerconfigjson", "secretName", pullSecretName)
+		return err
+	}
+
+	changed := false
+	if existingAuths.Auths == nil {
+		existingAuths.Auths = map[string]dockerConfigAuth{}
+	}
+
+	// If there are multiple pullsecrets for the same registry,
+	// keep the first one that was already present. Do not override unless explicitly requested (for rotation)
+	for reg, entry := range newAuths.Auths {
+		if _, authAlreadyExists := existingAuths.Auths[reg]; !authAlreadyExists {
+			existingAuths.Auths[reg] = entry
+			changed = true
+		} else {
+			if overwrite {
+				existingAuths.Auths[reg] = entry
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	// Marshal and update
+	mergedData, err := json.Marshal(existingAuths)
+	if err != nil {
+		log.Error(err, "failed to marshal updated docker config json")
+		return err
+	}
+	applicationPullSecret.Data[corev1.DockerConfigJsonKey] = mergedData
+
+	if err := r.Client.Update(ctx, applicationPullSecret); err != nil {
+		log.Error(err, "failed to update application pull secret", "secretName", applicationPullSecretName)
+		return err
+	}
+
+	log.Info("Application pull secret updated with new registry auth", "application", applicationName)
+	return nil
+
+}
+
+func (r *ImageRepositoryReconciler) removePullSecretFromApplicationPullSecret(ctx context.Context, imageRepository *imagerepositoryv1alpha1.ImageRepository) error {
+	log := ctrllog.FromContext(ctx)
+
+	applicationPullSecretName := getApplicationPullSecretName(imageRepository.Labels[ApplicationNameLabelName])
+	applicationPullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: applicationPullSecretName, Namespace: imageRepository.Namespace}, applicationPullSecret); err != nil {
+		if errors.IsNotFound(err) {
+			// Nothing to remove the pullsecret from
+			return nil
+		}
+		log.Error(err, "failed to get application pull secret", "secretName", applicationPullSecretName)
+		return err
+	}
+
+	// Get the pull secret that is being removed
+	pullSecret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: imageRepository.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}, pullSecret); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Pull secret already deleted, cannot identify which registry auths to remove", "secretName", imageRepository.Status.Credentials.PullSecretName)
+			return nil
+		}
+		log.Error(err, "failed to get pull secret", "secretName", imageRepository.Status.Credentials.PullSecretName)
+		return err
+	}
+	if pullSecret.Type != corev1.SecretTypeDockerConfigJson {
+		log.Info("Skipping secret due to unexpected type", "secretName", imageRepository.Status.Credentials.PullSecretName, "type", pullSecret.Type)
+		return nil
+	}
+
+	dockerConfigDataBytes, ok := pullSecret.Data[corev1.DockerConfigJsonKey]
+	if !ok {
+		log.Info("Missing .dockerconfigjson key", "secretName", imageRepository.Status.Credentials.PullSecretName)
+		return nil
+	}
+
+	var toRemoveAuths dockerConfigJson
+	if err := json.Unmarshal(dockerConfigDataBytes, &toRemoveAuths); err != nil {
+		log.Error(err, "failed to unmarshal .dockerconfigjson", "secretName", imageRepository.Status.Credentials.PullSecretName)
+		return err
+	}
+
+	var existingAuths dockerConfigJson
+	if err := json.Unmarshal(applicationPullSecret.Data[corev1.DockerConfigJsonKey], &existingAuths); err != nil {
+		log.Error(err, "failed to unmarshal application .dockerconfigjson", "secretName", applicationPullSecretName)
+		return err
+	}
+
+	if existingAuths.Auths == nil {
+		return nil
+	}
+
+	imageRepositoriesList := &imagerepositoryv1alpha1.ImageRepositoryList{}
+	if err := r.Client.List(ctx, imageRepositoriesList, &client.ListOptions{Namespace: imageRepository.Namespace}); err != nil {
+		log.Error(err, "failed to list image repositories")
+		return err
+	}
+
+	changed := false
+	for reg := range toRemoveAuths.Auths {
+		// Check if there’s another IR with the same repo URL. In that case
+		// we don't remove the record for the registry pullsecret completely, but replace it
+		// with pullsecret from this other IR.
+		foundImageRepositoryWithSameUrl := false
+
+		for _, otherIR := range imageRepositoriesList.Items {
+			// Skip the current IR that contains the secret we are removing
+			if otherIR.ObjectMeta.Name == imageRepository.ObjectMeta.Name {
+				continue
+			}
+			// Must match the same registry URL
+			if otherIR.Status.Image.URL != imageRepository.Status.Image.URL {
+				continue
+			}
+
+			// Get the other IR pull secret
+			otherIRPullSecret := &corev1.Secret{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Name: otherIR.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}, otherIRPullSecret); err != nil {
+				if errors.IsNotFound(err) {
+					log.Info("Pull secret not found", "secretName", otherIR.Status.Credentials.PullSecretName)
+					// We can continue looking for another alternative
+					continue
+				}
+				log.Error(err, "failed to get pull secret", "secretName", otherIR.Status.Credentials.PullSecretName)
+				return err
+			}
+			if otherIRPullSecret.Type != corev1.SecretTypeDockerConfigJson {
+				continue
+			}
+
+			otherIRDockerConfigDataBytes, ok := otherIRPullSecret.Data[corev1.DockerConfigJsonKey]
+			if !ok {
+				continue
+			}
+
+			var otherIRConfig dockerConfigJson
+			if err := json.Unmarshal(otherIRDockerConfigDataBytes, &otherIRConfig); err != nil {
+				continue
+			}
+
+			// We found another Image Repository with the same registry URL and viable pullsecret to
+			// replace the secret being removed.
+			if replacement, ok := otherIRConfig.Auths[reg]; ok {
+				existingAuths.Auths[reg] = replacement
+				foundImageRepositoryWithSameUrl = true
+				changed = true
+				break
+			}
+		}
+
+		if !foundImageRepositoryWithSameUrl {
+			// No other IR with the same url found, safe to remove the auth entry
+			if _, exists := existingAuths.Auths[reg]; exists {
+				delete(existingAuths.Auths, reg)
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	// Marshal and update
+	updatedData, err := json.Marshal(existingAuths)
+	if err != nil {
+		log.Error(err, "failed to marshal updated docker config json after deletion")
+		return err
+	}
+	applicationPullSecret.Data[corev1.DockerConfigJsonKey] = updatedData
+
+	if err := r.Client.Update(ctx, applicationPullSecret); err != nil {
+		log.Error(err, "failed to update application pull secret after removing registry auth", "secretName", applicationPullSecretName)
+		return err
+	}
+
+	log.Info("Application pull secret updated after removing registry auth", "application", imageRepository.Labels[ApplicationNameLabelName])
+	return nil
 }

--- a/internal/controller/imagerepository_controller_service_account.go
+++ b/internal/controller/imagerepository_controller_service_account.go
@@ -237,9 +237,9 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 	log := ctrllog.FromContext(ctx)
 
 	componentSaName := getComponentSaName(imageRepository.Labels[ComponentNameLabelName])
-	applicationSaName := getApplicationSaName(imageRepository.Labels[ApplicationNameLabelName])
 	pushSecretName := imageRepository.Status.Credentials.PushSecretName
-	pullSecretName := imageRepository.Status.Credentials.PullSecretName
+	applicationName := imageRepository.Labels[ApplicationNameLabelName]
+	applicationPullSecretName := getApplicationPullSecretName(applicationName)
 
 	// link secret to service account if isn't linked already
 	if err := r.linkSecretToServiceAccount(ctx, buildPipelineServiceAccountName, pushSecretName, imageRepository.Namespace, false); err != nil {
@@ -267,14 +267,14 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 		}
 
 		// link secret to service account if isn't linked already
-		if err := r.linkSecretToServiceAccount(ctx, applicationSaName, pullSecretName, imageRepository.Namespace, true); err != nil {
-			log.Error(err, "failed to link secret to service account", "saName", applicationSaName, "SecretName", pullSecretName, l.Action, l.ActionUpdate)
+		if err := r.linkSecretToServiceAccount(ctx, NamespaceServiceAccountName, applicationPullSecretName, imageRepository.Namespace, true); err != nil {
+			log.Error(err, "failed to link secret to service account", "saName", NamespaceServiceAccountName, "SecretName", applicationPullSecretName, l.Action, l.ActionUpdate)
 			return err
 		}
 
 		// clean duplicate secret links
-		if err := r.cleanUpSecretInServiceAccount(ctx, applicationSaName, pullSecretName, imageRepository.Namespace, true); err != nil {
-			log.Error(err, "failed to clean up secret in service account", "saName", applicationSaName, "SecretName", pullSecretName, l.Action, l.ActionUpdate)
+		if err := r.cleanUpSecretInServiceAccount(ctx, NamespaceServiceAccountName, applicationPullSecretName, imageRepository.Namespace, true); err != nil {
+			log.Error(err, "failed to clean up secret in service account", "saName", NamespaceServiceAccountName, "SecretName", applicationPullSecretName, l.Action, l.ActionUpdate)
 			return err
 		}
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -127,7 +127,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&ApplicationPullServiceAccountCreator{
+	err = (&ApplicationPullSecretCreator{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)


### PR DESCRIPTION
Previously, we had a SA for each application. Now we will have only pull secret for application that will be linked to SA
"konflux-integration-runner" that will be in each namespace.

The new pull secret for application is an aggregated secret, that contains records for each image repository.

[STONEBLD-3611](https://issues.redhat.com//browse/STONEBLD-3611)