### PR TITLE
fix(STONEBLD-3738): Disable leader-elect since replicas == 1

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,10 @@ spec:
         command:
         - /manager
         args:
-          - --leader-elect
+          # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
+          # https://dev.to/sklarsa/how-to-add-kubernetes-powered-leader-election-to-your-go-apps-57jh
+          # NOTE: Re-enable this when replicas > 1
+          - --leader-elect=false
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager


### PR DESCRIPTION
Using leader election when you only have 1 replica is inefficient, adds load to the API server, and makes the service excessively sensitive to API server load.