### PR TITLE
feat: add required tagging of test clusters

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -101,7 +101,7 @@ spec:
         - name: id
           value: $(context.pipelineRun.name)
         - name: tags
-          value: env=konflux,user=image-controller
+          value: 'owner=konflux-devprod@redhat.com,project=Konflux,created-by=integration-pipeline,component=image-controller'
         - name: debug
           value: 'false'
         - name: ownerKind


### PR DESCRIPTION
### Note: E2E tests don't have to pass to safely merge this PR
See more details in [this PR](https://github.com/konflux-ci/build-service/pull/486#issue-3465218041)