### PR TITLE
addPullSecretAuthToApplicationPullSecret shouldn't return error when

### DIFF
--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -1110,7 +1110,7 @@ func (r *ImageRepositoryReconciler) addPullSecretAuthToApplicationPullSecret(ctx
 	application := &compapiv1alpha1.Application{}
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: applicationName, Namespace: namespace}, application); err != nil {
 		log.Error(err, "failed to get Application", "application", applicationName)
-		return err
+		return nil
 	}
 
 	applicationPullSecretName := getApplicationPullSecretName(applicationName)


### PR DESCRIPTION
application doesn't exist

as it will be looping endlessly

either something wrong might have happened in the cluster, or application name label has just wrong name