### PR TITLE
Update notification-resetter memory resources

### DIFF
--- a/config/repository_notification_resetter/cronjob.yaml
+++ b/config/repository_notification_resetter/cronjob.yaml
@@ -34,10 +34,10 @@ spec:
             resources:
               limits:
                 cpu: 500m
-                memory: 1024Mi
+                memory: 768Mi
               requests:
                 cpu: 150m
-                memory: 512Mi
+                memory: 768Mi
             securityContext:
               readOnlyRootFilesystem: true
           restartPolicy: OnFailure

--- a/config/repository_notification_resetter/cronjob.yaml
+++ b/config/repository_notification_resetter/cronjob.yaml
@@ -34,10 +34,10 @@ spec:
             resources:
               limits:
                 cpu: 500m
-                memory: 768Mi
+                memory: 1024Mi
               requests:
                 cpu: 150m
-                memory: 768Mi
+                memory: 1024Mi
             securityContext:
               readOnlyRootFilesystem: true
           restartPolicy: OnFailure

--- a/config/repository_notification_resetter/cronjob.yaml
+++ b/config/repository_notification_resetter/cronjob.yaml
@@ -34,10 +34,10 @@ spec:
             resources:
               limits:
                 cpu: 500m
-                memory: 512Mi
+                memory: 1024Mi
               requests:
                 cpu: 150m
-                memory: 128Mi
+                memory: 512Mi
             securityContext:
               readOnlyRootFilesystem: true
           restartPolicy: OnFailure


### PR DESCRIPTION
Number of handled repositories raised and the cronjob is randomly OOM killed. The memory was set very low and might fall into unsafe `limit` range with higher OOM kill risk - this is to remediate.

Relates to [KONFLUX-13244](https://redhat.atlassian.net/browse/KONFLUX-13244)



[KONFLUX-13244]: https://redhat.atlassian.net/browse/KONFLUX-13244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ