### PR TITLE
fix: use upstream version of deploy task

### DIFF
--- a/e2e-tests/pipelines/konflux-e2e-tests.yaml
+++ b/e2e-tests/pipelines/konflux-e2e-tests.yaml
@@ -106,7 +106,7 @@ spec:
         - name: cluster-access-secret
           value: kfg-$(context.pipelineRun.name)
         - name: overrides-yaml
-          value:
+          value: |
             - name: image-controller
               git:
                 - sourceRepo: konflux-ci/image-controller

--- a/e2e-tests/pipelines/konflux-e2e-tests.yaml
+++ b/e2e-tests/pipelines/konflux-e2e-tests.yaml
@@ -97,34 +97,33 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog
+            value: https://github.com/konflux-ci/konflux-ci
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+            value: .tekton/tasks/deploy-konflux/task.yaml
       params:
         - name: cluster-access-secret
           value: kfg-$(context.pipelineRun.name)
-        - name: component-name
-          value: image-controller
-        - name: component-pr-owner
-          value: $(tasks.test-metadata.results.pull-request-author)
-        - name: component-pr-sha
-          value: $(tasks.test-metadata.results.git-revision)
-        - name: component-pr-source-branch
-          value: $(tasks.test-metadata.results.source-repo-branch)
-        - name: oci-ref
-          value: $(params.oci-container-repo):$(context.pipelineRun.name)
-        - name: oci-credentials
+        - name: overrides-yaml
+          value:
+            - name: image-controller
+              git:
+                - sourceRepo: konflux-ci/image-controller
+                  remote:
+                    repo: $(tasks.test-metadata.results.git-url)
+                    ref: $(tasks.test-metadata.results.git-revision)
+              images:
+                - orig: quay.io/konflux-ci/image-controller
+                  replacement: $(tasks.test-metadata.results.container-image)
+        - name: konflux-ready-timeout
+          value: "30m"
+        - name: oci-container-repo
+          value: $(params.oci-container-repo)
+        - name: oci-container-repo-credentials-secret
           value: $(params.konflux-test-infra-secret)
-        - name: component-image-repository
-          value: $(tasks.test-metadata.results.instrumented-container-repo)
-        - name: component-image-tag
-          value: $(tasks.test-metadata.results.instrumented-container-tag)
-        - name: build-credentials
-          value: "konflux-e2e-secrets"
-        - name: harden-kyverno
-          value: "true"
+        - name: pipeline-run-name
+          value: $(context.pipelineRun.name)
     - name: image-controller-e2e-tests
       timeout: 2h
       runAfter:


### PR DESCRIPTION
Use upstream [deploy-konflux task](https://github.com/konflux-ci/konflux-ci/tree/main/.tekton/tasks/deploy-konflux) in image-controller CI, which will use latest from other component while deploying konflux.