### PR TITLE
fix: protect RepositoryTimesForMetrics from concurrent map access

### DIFF
--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -86,10 +86,7 @@ func (r *ImageRepositoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func setMetricsTime(idForMetrics string, reconcileStartTime time.Time) {
-	_, timeRecorded := metrics.RepositoryTimesForMetrics[idForMetrics]
-	if !timeRecorded {
-		metrics.RepositoryTimesForMetrics[idForMetrics] = reconcileStartTime
-	}
+	metrics.SetRepositoryTimeIfAbsent(idForMetrics, reconcileStartTime)
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=imagerepositories,verbs=get;list;watch;create;update;patch;delete
@@ -122,7 +119,7 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if !imageRepository.DeletionTimestamp.IsZero() {
 		// remove component from metrics map
-		delete(metrics.RepositoryTimesForMetrics, repositoryIdForMetrics)
+		metrics.DeleteRepositoryTime(repositoryIdForMetrics)
 
 		// Reread quay token
 		r.QuayClient, err = r.BuildQuayClient()
@@ -209,12 +206,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if imageRepository.Status.State == imagerepositoryv1alpha1.ImageRepositoryStateFailed {
-		provisionTime, timeRecorded := metrics.RepositoryTimesForMetrics[repositoryIdForMetrics]
+		provisionTime, timeRecorded := metrics.GetRepositoryTime(repositoryIdForMetrics)
 		if timeRecorded {
 			metrics.ImageRepositoryProvisionFailureTimeMetric.Observe(time.Since(provisionTime).Seconds())
 
 			// remove component from metrics map
-			delete(metrics.RepositoryTimesForMetrics, repositoryIdForMetrics)
+			metrics.DeleteRepositoryTime(repositoryIdForMetrics)
 		}
 
 		return ctrl.Result{}, nil
@@ -471,12 +468,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// we are adding to map only for new provision, not for some partial actions,
 	// so report time only if time was recorded
-	provisionTime, timeRecorded := metrics.RepositoryTimesForMetrics[repositoryIdForMetrics]
+	provisionTime, timeRecorded := metrics.GetRepositoryTime(repositoryIdForMetrics)
 	if timeRecorded {
 		metrics.ImageRepositoryProvisionTimeMetric.Observe(time.Since(provisionTime).Seconds())
 	}
 	// remove component from metrics map
-	delete(metrics.RepositoryTimesForMetrics, repositoryIdForMetrics)
+	metrics.DeleteRepositoryTime(repositoryIdForMetrics)
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,8 +33,30 @@ var (
 		Help:      "The time in seconds spent from the moment of Image repository provision request to Image repository failure.",
 	})
 
-	RepositoryTimesForMetrics = map[string]time.Time{}
+	repositoryTimesForMetrics   = map[string]time.Time{}
+	repositoryTimesForMetricsMu sync.Mutex
 )
+
+func SetRepositoryTimeIfAbsent(key string, t time.Time) {
+	repositoryTimesForMetricsMu.Lock()
+	defer repositoryTimesForMetricsMu.Unlock()
+	if _, ok := repositoryTimesForMetrics[key]; !ok {
+		repositoryTimesForMetrics[key] = t
+	}
+}
+
+func GetRepositoryTime(key string) (time.Time, bool) {
+	repositoryTimesForMetricsMu.Lock()
+	defer repositoryTimesForMetricsMu.Unlock()
+	t, ok := repositoryTimesForMetrics[key]
+	return t, ok
+}
+
+func DeleteRepositoryTime(key string) {
+	repositoryTimesForMetricsMu.Lock()
+	defer repositoryTimesForMetricsMu.Unlock()
+	delete(repositoryTimesForMetrics, key)
+}
 
 func (m *ImageControllerMetrics) InitMetrics(registerer prometheus.Registerer) error {
 	// controller metrics

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,82 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+func clearRepositoryTimes() {
+	repositoryTimesForMetricsMu.Lock()
+	defer repositoryTimesForMetricsMu.Unlock()
+	for k := range repositoryTimesForMetrics {
+		delete(repositoryTimesForMetrics, k)
+	}
+}
+
+func TestSetRepositoryTimeIfAbsent(t *testing.T) {
+	t.Cleanup(clearRepositoryTimes)
+
+	t1 := time.Now()
+	t2 := t1.Add(time.Second)
+
+	SetRepositoryTimeIfAbsent("key1", t1)
+	got, ok := GetRepositoryTime("key1")
+	if !ok || !got.Equal(t1) {
+		t.Fatalf("expected %v, got %v (ok=%v)", t1, got, ok)
+	}
+
+	SetRepositoryTimeIfAbsent("key1", t2)
+	got, ok = GetRepositoryTime("key1")
+	if !ok || !got.Equal(t1) {
+		t.Fatalf("expected original time %v to be preserved, got %v", t1, got)
+	}
+}
+
+func TestGetRepositoryTime(t *testing.T) {
+	t.Cleanup(clearRepositoryTimes)
+
+	_, ok := GetRepositoryTime("missing")
+	if ok {
+		t.Fatal("expected ok=false for missing key")
+	}
+
+	now := time.Now()
+	SetRepositoryTimeIfAbsent("present", now)
+	got, ok := GetRepositoryTime("present")
+	if !ok || !got.Equal(now) {
+		t.Fatalf("expected %v, got %v (ok=%v)", now, got, ok)
+	}
+}
+
+func TestDeleteRepositoryTime(t *testing.T) {
+	t.Cleanup(clearRepositoryTimes)
+
+	DeleteRepositoryTime("missing")
+
+	now := time.Now()
+	SetRepositoryTimeIfAbsent("key1", now)
+	DeleteRepositoryTime("key1")
+	_, ok := GetRepositoryTime("key1")
+	if ok {
+		t.Fatal("expected key to be deleted")
+	}
+}
+
+func TestRepositoryTimeConcurrency(t *testing.T) {
+	t.Cleanup(clearRepositoryTimes)
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			key := "key"
+			now := time.Now()
+			SetRepositoryTimeIfAbsent(key, now)
+			GetRepositoryTime(key)
+			DeleteRepositoryTime(key)
+		}(i)
+	}
+	wg.Wait()
+}
 
 func TestInitMetrics(t *testing.T) {
 	getTestClient := func() (quay.QuayService, error) {


### PR DESCRIPTION
The global map was read/written/deleted from multiple reconciler goroutines without synchronization, which can cause a fatal panic. Replace the exported map with mutex-protected helper functions.