### PR TITLE
Set explicit TLS minimum version for Quay HTTP client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -412,7 +412,8 @@ func buildQuayHttpClient() (*http.Client, error) {
 
 		// Configure TLS with the custom CA pool
 		transport.TLSClientConfig = &tls.Config{
-			RootCAs: caCertPool,
+			RootCAs:    caCertPool,
+			MinVersion: tls.VersionTLS12,
 		}
 
 		setupLog.Info("Additional CA certificate loaded successfully")


### PR DESCRIPTION
Explicitly set MinVersion to TLS 1.2 on the tls.Config used for the Quay HTTP client as a defense-in-depth measure against potential TLS downgrade.