### PR TITLE
feat: add dual-group Component support and rename appstudio strings to konflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ For example: `quayapiurl: https://quay.local:8443/api/v1`
 If a self-signed TLS certifiacte is used in self-hosted Quay instance,
 mount CA cert into the operator pod and set `QUAY_ADDITIONAL_CA` environament variable to point to the CA cert file.
 
+## Image repository API groups
+- New API group : `konflux-ci.dev/v1alpha1`
+- Old API group : `appstudio.redhat.com/v1alpha1`
+
+Old API group will be eventually removed in favor of new one.
+
 ## General purpose image repository
 
 ### Requesting image repository
 
 To request an image repository one should create `ImageRepository` custom resource:
 ```yaml
-apiVersion: appstudio.redhat.com/v1alpha1
+apiVersion: konflux-ci.dev/v1alpha1 // or old API group appstudio.redhat.com/v1alpha1
 kind: ImageRepository
 metadata:
   name: imagerepository-sample
@@ -51,7 +57,7 @@ As a result, a public image repository `quay.io/my-org/test-ns/imagerepository-s
 When `status.state` is set to `ready`, the image repository is ready for use.
 Additional information about the image repository one may obtain from the `ImageRepository` object `status`:
 ```yaml
-apiVersion: appstudio.redhat.com/v1alpha1
+apiVersion: konflux-ci.dev/v1alpha1 // or old API group appstudio.redhat.com/v1alpha1
 kind: ImageRepository
 metadata:
   name: imagerepository-sample
@@ -137,7 +143,7 @@ After token rotation, the `spec.credentials.regenerate-namespace-pull-token` sec
 
 **NOTE**
 
-ImageRepository will have annotation `image-controller.appstudio.redhat.com/namespace-pull-secret-ensured` set to `true` which means that namespace secret was created and namespace robot account was created with proper permissions.
+ImageRepository will have annotation `build.konflux-ci.dev/namespace-pull-secret-ensured` (`image-controller.appstudio.redhat.com/namespace-pull-secret-ensured` in case of old ImageRepository API Group used) set to `true` which means that namespace secret was created and namespace robot account was created with proper permissions.
 
 When secret is removed by mistake, it can be recreated by removal of that annotation.
 
@@ -180,7 +186,7 @@ After any successful operation, `status.message` is cleared.
 By default, if the ImageRepository resource is deleted, the repository it created
 in Quay will get deleted as well.
 
-In order to skip the deletion of the repository in Quay, the `image-controller.appstudio.redhat.com/skip-repository-deletion` annotation should be set to "true".
+In order to skip the deletion of the repository in Quay, the `build.konflux-ci.dev/skip-repository-deletion` (`image-controller.appstudio.redhat.com/skip-repository-deletion` in case of old ImageRepository API Group used) annotation should be set to "true".
 
 ## Konflux Component image repository
 
@@ -189,8 +195,8 @@ In order to skip the deletion of the repository in Quay, the `image-controller.a
 There is a special use case for image repository that stores user's `Component` built images.
 
 To request image repository provision for the `Component`'s builds, the following labels must be added on `ImageRepository` creation:
- - `appstudio.redhat.com/component` with the `Component` name as the value
- - `appstudio.redhat.com/application` with the `Application` name to which the `Component` belongs to.
+ - `build.konflux-ci.dev/component` (`appstudio.redhat.com/component` in case of old ImageRepository API Group used) with the `Component` name as the value
+ - `appstudio.redhat.com/application` with the `Application` name to which the `Component` belongs to (used only in case of old ImageRepository API Group used).
 
 ---
 **NOTE**
@@ -213,27 +219,27 @@ All other functionality is the same as for general purpose object.
 
 To request an image repository for storing `Component` built images, one should create `ImageRepository` custom resource:
 ```yaml
-apiVersion: appstudio.redhat.com/v1alpha1
+apiVersion: konflux-ci.dev/v1alpha1 // or old API group appstudio.redhat.com/v1alpha1
 kind: ImageRepository
 metadata:
   name: imagerepository-for-component-sample
   namespace: test-ns
   annotations:
-    image-controller.appstudio.redhat.com/update-component-image: 'true'
+    build.konflux-ci.dev/update-component-image: 'true' // `image-controller.appstudio.redhat.com/update-component-image` in case of old ImageRepository API Group used
   labels:
-    appstudio.redhat.com/component: my-component
-    appstudio.redhat.com/application: my-app
+    build.konflux-ci.dev/component: my-component // `appstudio.redhat.com/component` in case of old ImageRepository API Group used
+    appstudio.redhat.com/application: my-app // used only in case of old ImageRepository API Group used
 ```
 As a result, a public image repository `quay.io/my-org/test-ns/my-app/my-component` will be created.
 When `status.state` is set to `ready`, the image repository is ready for use.
 
-Annotation `image-controller.appstudio.redhat.com/update-component-image` is required when using
+Annotation `build.konflux-ci.dev/update-component-image` (`image-controller.appstudio.redhat.com/update-component-image` in case of old ImageRepository API Group used) is required when using
 ImageRepository with Component, as it will set Component's `spec.containerImage` allowing
 Build service controller to continue.
 
 Additional information about the image repository one may obtain from the `ImageRepository` object `status`:
 ```yaml
-apiVersion: appstudio.redhat.com/v1alpha1
+apiVersion: konflux-ci.dev/v1alpha1 // or old API group appstudio.redhat.com/v1alpha1
 kind: ImageRepository
 metadata:
   name: imagerepository-for-component-sample
@@ -262,7 +268,7 @@ status:
 To request the controller to set up an image repository for a component, annotate the `Component` with `image.redhat.com/generate: '{"visibility": "public"}'` or `image.redhat.com/generate: '{"visibility": "private"}'` depending on desired repository visibility.
 
 ```yaml
-apiVersion: appstudio.redhat.com/v1alpha1
+apiVersion: konflux-ci.dev/v1alpha1 // or old API group appstudio.redhat.com/v1alpha1
 kind: Component
 metadata:
   annotations:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,6 +51,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	irv1alpha1 "github.com/konflux-ci/image-controller/api/konflux/v1alpha1"
 	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1" // remove after fully migrated to new group
@@ -85,7 +86,8 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(compapiv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(compapiv1alpha1.AddToScheme(scheme)) // remove after fully migrated to new group
+	utilruntime.Must(compv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(imagerepositoryv1alpha1.AddToScheme(scheme)) // remove after fully migrated to new group
 	utilruntime.Must(irv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,7 @@ rules:
   - update
 - apiGroups:
   - appstudio.redhat.com
+  - konflux-ci.dev
   resources:
   - components
   verbs:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/h2non/gock v1.2.0
-	github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104
+	github.com/konflux-ci/application-api v0.0.0-20260727123715-2999a91451c6
 	github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127103713-95b5b5e04a62
 	github.com/onsi/ginkgo/v2 v2.26.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104 h1:OoqVKDkEgLfVGoCuqIzTn5QsRgk9mklgvfXjkLXjK58=
-github.com/konflux-ci/application-api v0.0.0-20260529131129-a9594acdc104/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
+github.com/konflux-ci/application-api v0.0.0-20260727123715-2999a91451c6 h1:zKKze/yi6mNUlubVW0LRRorZh7cZ/yQ1cSMALqHFQgk=
+github.com/konflux-ci/application-api v0.0.0-20260727123715-2999a91451c6/go.mod h1:948Z+a1IbfRT0RtoHzWWSN9YEucSbMJTHaMhz7dVICc=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127103713-95b5b5e04a62 h1:lMTed+H0EesSqsH3iQXtLoy/+SpbBT0BS1J0izeEtFM=
 github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20251127103713-95b5b5e04a62/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -262,7 +262,7 @@ func (r *ApplicationPullSecretCreator) createApplicationPullSecret(ctx context.C
 			Name:      applicationPullSecretName,
 			Namespace: application.Namespace,
 			Labels: map[string]string{
-				InternalSecretLabelName: "true",
+				InternalSecretLabelNameOldModel: "true",
 			},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,

--- a/internal/controller/application_controller_test.go
+++ b/internal/controller/application_controller_test.go
@@ -58,10 +58,10 @@ var _ = Describe("Application controller", func() {
 		AfterEach(func() {
 			deleteServiceAccount(types.NamespacedName{Name: IntegrationServiceAccountName, Namespace: appSecretTestNamespace})
 			deleteSecret(namespacePullSecretName)
-			deleteImageRepository_old(imageRepository2Key)
-			deleteImageRepository_old(imageRepository1Key)
-			deleteComponent(component1Key)
-			deleteComponent(component2Key)
+			deleteImageRepositoryOldModel(imageRepository2Key)
+			deleteImageRepositoryOldModel(imageRepository1Key)
+			deleteComponentOldModel(component1Key)
+			deleteComponentOldModel(component2Key)
 			deleteApplication(applicationKey)
 			deleteSecret(types.NamespacedName{Name: pullSecret1, Namespace: appSecretTestNamespace})
 			deleteSecret(types.NamespacedName{Name: pullSecret2, Namespace: appSecretTestNamespace})
@@ -72,8 +72,8 @@ var _ = Describe("Application controller", func() {
 		})
 
 		It("should create empty application pull secret and without link it to not existing integration SA, because no components are owned by application", func() {
-			createComponent_old(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			createApplication_old(applicationConfig{ApplicationKey: applicationKey})
+			createComponentOldModel(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
 
 			// wait until application secret is created
 			applicationSecret := waitSecretExist(namespacePullSecretName)
@@ -91,8 +91,8 @@ var _ = Describe("Application controller", func() {
 
 		It("should create empty application pull secret and link it to integration SA, because no components are owned by application", func() {
 			createServiceAccount(appSecretTestNamespace, IntegrationServiceAccountName)
-			createComponent_old(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			createApplication_old(applicationConfig{ApplicationKey: applicationKey})
+			createComponentOldModel(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
 
 			// wait until empty secret is linked to integration SA
 			Eventually(func() bool {
@@ -132,9 +132,9 @@ var _ = Describe("Application controller", func() {
 			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, true)
 
 			// will trigger application controller and create empty secret
-			application := createApplication_old(applicationConfig{ApplicationKey: applicationKey})
-			component1 := createComponent_old(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			component2 := createComponent_old(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+			application := createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
+			component1 := createComponentOldModel(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			component2 := createComponentOldModel(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
 
 			// wait until empty secret is linked to integration SA
 			Eventually(func() bool {
@@ -173,9 +173,9 @@ var _ = Describe("Application controller", func() {
 
 			// create image repository with finalizer so it won't try to provision repo
 			// also without component & application labels so controller won't try any secrets linking
-			imageConfig1 := imageRepositoryConfig_old{
+			imageConfig1 := imageRepositoryConfigOldModel{
 				ResourceKey: &imageRepository1Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
+				Finalizers:  []string{ImageRepositoryFinalizerOldModel},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Component",
@@ -183,11 +183,11 @@ var _ = Describe("Application controller", func() {
 					UID:        component1.UID,
 				}},
 				// set annotation so that imageRepository isn't updated with the annotation
-				Annotations: map[string]string{namespacePullSecretEnsuredAnnotation: "true"},
+				Annotations: map[string]string{namespacePullSecretEnsuredAnnotationOldModel: "true"},
 			}
-			imageConfig2 := imageRepositoryConfig_old{
+			imageConfig2 := imageRepositoryConfigOldModel{
 				ResourceKey: &imageRepository2Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
+				Finalizers:  []string{ImageRepositoryFinalizerOldModel},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Component",
@@ -195,13 +195,13 @@ var _ = Describe("Application controller", func() {
 					UID:        component2.UID,
 				}},
 				// set annotation so that imageRepository isn't updated with the annotation
-				Annotations: map[string]string{namespacePullSecretEnsuredAnnotation: "true"},
+				Annotations: map[string]string{namespacePullSecretEnsuredAnnotationOldModel: "true"},
 			}
-			ir1 := createImageRepository_old(imageConfig1)
-			ir2 := createImageRepository_old(imageConfig2)
+			ir1 := createImageRepositoryOldModel(imageConfig1)
+			ir2 := createImageRepositoryOldModel(imageConfig2)
 			Eventually(func() bool {
-				ir1 = getImageRepository_old(*imageConfig1.ResourceKey)
-				ir2 = getImageRepository_old(*imageConfig2.ResourceKey)
+				ir1 = getImageRepositoryOldModel(*imageConfig1.ResourceKey)
+				ir2 = getImageRepositoryOldModel(*imageConfig2.ResourceKey)
 				return ir1.Status.State != "" && ir2.Status.State != ""
 			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 
@@ -218,12 +218,12 @@ var _ = Describe("Application controller", func() {
 
 			// set image repository component & application labels
 			ir1.Labels = map[string]string{
-				ApplicationNameLabelName: applicationKey.Name,
-				ComponentNameLabelName:   component1.Name,
+				ApplicationNameLabelName:       applicationKey.Name,
+				ComponentNameLabelNameOldModel: component1.Name,
 			}
 			ir2.Labels = map[string]string{
-				ApplicationNameLabelName: applicationKey.Name,
-				ComponentNameLabelName:   component2.Name,
+				ApplicationNameLabelName:       applicationKey.Name,
+				ComponentNameLabelNameOldModel: component2.Name,
 			}
 			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())
@@ -288,9 +288,9 @@ var _ = Describe("Application controller", func() {
 			createDockerConfigSecret(pullSecret2Key, pullSecret2Data, false)
 
 			// will trigger application controller and create empty secret
-			application := createApplication_old(applicationConfig{ApplicationKey: applicationKey})
-			component1 := createComponent_old(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
-			component2 := createComponent_old(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
+			application := createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
+			component1 := createComponentOldModel(componentConfig{ComponentKey: component1Key, ComponentApplication: applicationKey.Name})
+			component2 := createComponentOldModel(componentConfig{ComponentKey: component2Key, ComponentApplication: applicationKey.Name})
 
 			// wait until empty secret is linked to integration SA
 			Eventually(func() bool {
@@ -329,9 +329,9 @@ var _ = Describe("Application controller", func() {
 
 			// create image repository with finalizer so it won't try to provision repo
 			// also without component & application labels so controller won't try any secrets linking
-			imageConfig1 := imageRepositoryConfig_old{
+			imageConfig1 := imageRepositoryConfigOldModel{
 				ResourceKey: &imageRepository1Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
+				Finalizers:  []string{ImageRepositoryFinalizerOldModel},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Component",
@@ -339,11 +339,11 @@ var _ = Describe("Application controller", func() {
 					UID:        component1.UID,
 				}},
 				// set annotation so that imageRepository isn't updated with the annotation
-				Annotations: map[string]string{namespacePullSecretEnsuredAnnotation: "true"},
+				Annotations: map[string]string{namespacePullSecretEnsuredAnnotationOldModel: "true"},
 			}
-			imageConfig2 := imageRepositoryConfig_old{
+			imageConfig2 := imageRepositoryConfigOldModel{
 				ResourceKey: &imageRepository2Key,
-				Finalizers:  []string{ImageRepositoryFinalizer},
+				Finalizers:  []string{ImageRepositoryFinalizerOldModel},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: "appstudio.redhat.com/v1alpha1",
 					Kind:       "Component",
@@ -351,13 +351,13 @@ var _ = Describe("Application controller", func() {
 					UID:        component2.UID,
 				}},
 				// set annotation so that imageRepository isn't updated with the annotation
-				Annotations: map[string]string{namespacePullSecretEnsuredAnnotation: "true"},
+				Annotations: map[string]string{namespacePullSecretEnsuredAnnotationOldModel: "true"},
 			}
-			ir1 := createImageRepository_old(imageConfig1)
-			ir2 := createImageRepository_old(imageConfig2)
+			ir1 := createImageRepositoryOldModel(imageConfig1)
+			ir2 := createImageRepositoryOldModel(imageConfig2)
 			Eventually(func() bool {
-				ir1 = getImageRepository_old(*imageConfig1.ResourceKey)
-				ir2 = getImageRepository_old(*imageConfig2.ResourceKey)
+				ir1 = getImageRepositoryOldModel(*imageConfig1.ResourceKey)
+				ir2 = getImageRepositoryOldModel(*imageConfig2.ResourceKey)
 				return ir1.Status.State != "" && ir2.Status.State != ""
 			}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 
@@ -374,12 +374,12 @@ var _ = Describe("Application controller", func() {
 
 			// set image repository component & application labels
 			ir1.Labels = map[string]string{
-				ApplicationNameLabelName: applicationKey.Name,
-				ComponentNameLabelName:   component1.Name,
+				ApplicationNameLabelName:       applicationKey.Name,
+				ComponentNameLabelNameOldModel: component1.Name,
 			}
 			ir2.Labels = map[string]string{
-				ApplicationNameLabelName: applicationKey.Name,
-				ComponentNameLabelName:   component2.Name,
+				ApplicationNameLabelName:       applicationKey.Name,
+				ComponentNameLabelNameOldModel: component2.Name,
 			}
 			Expect(k8sClient.Update(ctx, ir1)).To(Succeed())
 			Expect(k8sClient.Update(ctx, ir2)).To(Succeed())

--- a/internal/controller/component_image_controller.go
+++ b/internal/controller/component_image_controller.go
@@ -47,8 +47,8 @@ const (
 
 	ImageRepositoryComponentFinalizer = "image-controller.appstudio.openshift.io/image-repository"
 
-	ApplicationNameLabelName = "appstudio.redhat.com/application"
-	ComponentNameLabelName   = "appstudio.redhat.com/component"
+	ApplicationNameLabelName       = "appstudio.redhat.com/application"
+	ComponentNameLabelNameOldModel = "appstudio.redhat.com/component"
 )
 
 // GenerateRepositoryOpts defines patameters for image repository to be generated.
@@ -198,10 +198,10 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Name:      imageRepositoryName,
 				Namespace: component.Namespace,
 				Labels: map[string]string{
-					ComponentNameLabelName: component.Name,
+					ComponentNameLabelNameOldModel: component.Name,
 				},
 				Annotations: map[string]string{
-					updateComponentAnnotationName: "true",
+					updateComponentAnnotationNameOldModel: "true",
 				},
 			},
 			Spec: imagerepositoryv1alpha1.ImageRepositorySpec{

--- a/internal/controller/component_image_controller_test.go
+++ b/internal/controller/component_image_controller_test.go
@@ -60,12 +60,12 @@ var _ = Describe("Component image controller", func() {
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
-			createApplication_old(applicationConfig{ApplicationKey: applicationKey})
+			createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
 		})
 
 		AfterEach(func() {
 			deleteApplication(applicationKey)
-			deleteComponent(resourceImageProvisionKey)
+			deleteComponentOldModel(resourceImageProvisionKey)
 		})
 
 		It("should prepare environment", func() {
@@ -84,7 +84,7 @@ var _ = Describe("Component image controller", func() {
 
 		It("should do image repository provision", func() {
 			expectedVisibility := imagerepositoryv1alpha1.ImageVisibility("private")
-			createComponent_old(componentConfig{
+			createComponentOldModel(componentConfig{
 				ComponentKey:         resourceImageProvisionKey,
 				ComponentApplication: defaultComponentApplication,
 				Annotations: map[string]string{
@@ -98,27 +98,27 @@ var _ = Describe("Component image controller", func() {
 			Expect(k8sClient.List(ctx, imageRepositoriesList, &client.ListOptions{Namespace: resourceImageProvisionKey.Namespace})).To(Succeed())
 			Expect(imageRepositoriesList.Items).To(HaveLen(1))
 
-			component := getComponent(resourceImageProvisionKey)
+			component := getComponentOldModel(resourceImageProvisionKey)
 			// wait for imagerepository_controller to finish
-			waitImageRepositoryFinalizerOnImageRepository_old(imageRepositoryName)
-			imageRepository := getImageRepository_old(imageRepositoryName)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(imageRepositoryName)
+			imageRepository := getImageRepositoryOldModel(imageRepositoryName)
 
 			Expect(imageRepository.ObjectMeta.Labels[ApplicationNameLabelName]).To(Equal(component.Spec.Application))
-			Expect(imageRepository.ObjectMeta.Labels[ComponentNameLabelName]).To(Equal(component.Name))
+			Expect(imageRepository.ObjectMeta.Labels[ComponentNameLabelNameOldModel]).To(Equal(component.Name))
 			Expect(imageRepository.Spec.Image.Visibility).To(Equal(expectedVisibility))
 			Expect(imageRepository.ObjectMeta.OwnerReferences[0].UID).To(Equal(component.UID))
-			Expect(imageRepository.ObjectMeta.Annotations[updateComponentAnnotationName]).To(BeEmpty())
+			Expect(imageRepository.ObjectMeta.Annotations[updateComponentAnnotationNameOldModel]).To(BeEmpty())
 
-			component = getComponent(resourceImageProvisionKey)
+			component = getComponentOldModel(resourceImageProvisionKey)
 			Expect(component.Annotations[ImageAnnotationName]).To(BeEmpty())
 			Expect(component.Spec.ContainerImage).ToNot(BeEmpty())
 
-			deleteImageRepository_old(imageRepositoryName)
+			deleteImageRepositoryOldModel(imageRepositoryName)
 		})
 
 		It("should do image repository provision when component doesn't have application", func() {
 			expectedVisibility := imagerepositoryv1alpha1.ImageVisibility("private")
-			createComponent_old(componentConfig{
+			createComponentOldModel(componentConfig{
 				ComponentKey: resourceImageProvisionKey,
 				Annotations: map[string]string{
 					GenerateImageAnnotationName: "{\"visibility\": \"private\"}",
@@ -131,28 +131,28 @@ var _ = Describe("Component image controller", func() {
 			Expect(k8sClient.List(ctx, imageRepositoriesList, &client.ListOptions{Namespace: resourceImageProvisionKey.Namespace})).To(Succeed())
 			Expect(imageRepositoriesList.Items).To(HaveLen(1))
 
-			component := getComponent(resourceImageProvisionKey)
+			component := getComponentOldModel(resourceImageProvisionKey)
 			// wait for imagerepository_controller to finish
-			waitImageRepositoryFinalizerOnImageRepository_old(imageRepositoryWithoutApplicationName)
-			imageRepository := getImageRepository_old(imageRepositoryWithoutApplicationName)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(imageRepositoryWithoutApplicationName)
+			imageRepository := getImageRepositoryOldModel(imageRepositoryWithoutApplicationName)
 
 			_, applicationLabelExists := imageRepository.ObjectMeta.Labels[ApplicationNameLabelName]
 			Expect(applicationLabelExists).To(BeFalse())
-			Expect(imageRepository.ObjectMeta.Labels[ComponentNameLabelName]).To(Equal(component.Name))
+			Expect(imageRepository.ObjectMeta.Labels[ComponentNameLabelNameOldModel]).To(Equal(component.Name))
 			Expect(imageRepository.Spec.Image.Visibility).To(Equal(expectedVisibility))
 			Expect(imageRepository.ObjectMeta.OwnerReferences[0].UID).To(Equal(component.UID))
-			Expect(imageRepository.ObjectMeta.Annotations[updateComponentAnnotationName]).To(BeEmpty())
+			Expect(imageRepository.ObjectMeta.Annotations[updateComponentAnnotationNameOldModel]).To(BeEmpty())
 
-			component = getComponent(resourceImageProvisionKey)
+			component = getComponentOldModel(resourceImageProvisionKey)
 			Expect(component.Annotations[ImageAnnotationName]).To(BeEmpty())
 			Expect(component.Spec.ContainerImage).ToNot(BeEmpty())
 
-			deleteImageRepository_old(imageRepositoryWithoutApplicationName)
+			deleteImageRepositoryOldModel(imageRepositoryWithoutApplicationName)
 		})
 
 		It("should accept deprecated true value for repository options", func() {
 			expectedVisibility := imagerepositoryv1alpha1.ImageVisibility("public")
-			createComponent_old(componentConfig{
+			createComponentOldModel(componentConfig{
 				ComponentKey:         resourceImageProvisionKey,
 				ComponentApplication: defaultComponentApplication,
 				Annotations: map[string]string{
@@ -167,22 +167,22 @@ var _ = Describe("Component image controller", func() {
 			Expect(k8sClient.List(ctx, imageRepositoriesList, &client.ListOptions{Namespace: resourceImageProvisionKey.Namespace})).To(Succeed())
 			Expect(imageRepositoriesList.Items).To(HaveLen(1))
 
-			component := getComponent(resourceImageProvisionKey)
+			component := getComponentOldModel(resourceImageProvisionKey)
 			// wait for imagerepository_controller to finish
-			waitImageRepositoryFinalizerOnImageRepository_old(imageRepositoryName)
-			imageRepository := getImageRepository_old(imageRepositoryName)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(imageRepositoryName)
+			imageRepository := getImageRepositoryOldModel(imageRepositoryName)
 
 			Expect(imageRepository.ObjectMeta.Labels[ApplicationNameLabelName]).To(Equal(component.Spec.Application))
-			Expect(imageRepository.ObjectMeta.Labels[ComponentNameLabelName]).To(Equal(component.Name))
+			Expect(imageRepository.ObjectMeta.Labels[ComponentNameLabelNameOldModel]).To(Equal(component.Name))
 			Expect(imageRepository.Spec.Image.Visibility).To(Equal(expectedVisibility))
 			Expect(imageRepository.ObjectMeta.OwnerReferences[0].UID).To(Equal(component.UID))
-			Expect(imageRepository.ObjectMeta.Annotations[updateComponentAnnotationName]).To(BeEmpty())
+			Expect(imageRepository.ObjectMeta.Annotations[updateComponentAnnotationNameOldModel]).To(BeEmpty())
 
-			component = getComponent(resourceImageProvisionKey)
+			component = getComponentOldModel(resourceImageProvisionKey)
 			Expect(component.Annotations[ImageAnnotationName]).To(BeEmpty())
 			Expect(component.Spec.ContainerImage).ToNot(BeEmpty())
 
-			deleteImageRepository_old(imageRepositoryName)
+			deleteImageRepositoryOldModel(imageRepositoryName)
 			deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: imageTestNamespace})
 			deleteServiceAccount(types.NamespacedName{Name: IntegrationServiceAccountName, Namespace: imageTestNamespace})
 		})
@@ -194,9 +194,9 @@ var _ = Describe("Component image controller", func() {
 		var componentSaName = getComponentSaName(resourceImageErrorKey.Name)
 
 		It("should prepare environment", func() {
-			deleteComponent(resourceImageErrorKey)
+			deleteComponentOldModel(resourceImageErrorKey)
 			quay.ResetTestQuayClient()
-			createApplication_old(applicationConfig{ApplicationKey: applicationKey})
+			createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
 
 			createServiceAccount(imageTestNamespace, componentSaName)
 			createServiceAccount(imageTestNamespace, IntegrationServiceAccountName)
@@ -210,7 +210,7 @@ var _ = Describe("Component image controller", func() {
 		})
 
 		It("should do nothing if generate annotation is not set", func() {
-			createComponent_old(componentConfig{ComponentKey: resourceImageErrorKey, ComponentApplication: defaultComponentApplication})
+			createComponentOldModel(componentConfig{ComponentKey: resourceImageErrorKey, ComponentApplication: defaultComponentApplication})
 
 			time.Sleep(ensureTimeout)
 			waitComponentAnnotationGone(resourceImageErrorKey, GenerateImageAnnotationName)
@@ -222,18 +222,18 @@ var _ = Describe("Component image controller", func() {
 		})
 
 		It("should do nothing if imageRepository for the component already exists, with expected name", func() {
-			component := getComponent(resourceImageErrorKey)
+			component := getComponentOldModel(resourceImageErrorKey)
 			imageRepositoryName := fmt.Sprintf("imagerepository-for-%s-%s", component.Spec.Application, component.Name)
 			imageRepositoryKey := types.NamespacedName{Name: imageRepositoryName, Namespace: component.Namespace}
 
-			createImageRepository_old(imageRepositoryConfig_old{ResourceKey: &imageRepositoryKey})
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ResourceKey: &imageRepositoryKey})
 			// wait for imagerepository_controller to finish
-			waitImageRepositoryFinalizerOnImageRepository_old(imageRepositoryKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(imageRepositoryKey)
 			// add generate annotation and it will not create new ImageRepository
 			setComponentAnnotationValue(resourceImageErrorKey, GenerateImageAnnotationName, `{"visibility": "public"}`)
 			waitComponentAnnotationGone(resourceImageErrorKey, GenerateImageAnnotationName)
 
-			component = getComponent(resourceImageErrorKey)
+			component = getComponentOldModel(resourceImageErrorKey)
 			Expect(component.Annotations[ImageAnnotationName]).To(BeEmpty())
 			// just to double check that new ImageRepository wasn't created, which would add ContainerImage
 			Expect(component.Spec.ContainerImage).To(BeEmpty())
@@ -251,28 +251,28 @@ var _ = Describe("Component image controller", func() {
 				APIVersion: "appstudio.redhat.com/v1alpha1",
 			}))
 
-			deleteImageRepository_old(imageRepositoryKey)
+			deleteImageRepositoryOldModel(imageRepositoryKey)
 		})
 
 		It("should do nothing if imageRepository for the component already exists, with different name", func() {
-			component := getComponent(resourceImageErrorKey)
+			component := getComponentOldModel(resourceImageErrorKey)
 			imageRepositoryName := fmt.Sprintf("differently-named-%s-%s", component.Spec.Application, component.Name)
 			imageRepository := types.NamespacedName{Name: imageRepositoryName, Namespace: component.Namespace}
 			ownerReferences := []metav1.OwnerReference{
 				{Kind: "Component", Name: component.Name, UID: component.UID, APIVersion: "appstudio.redhat.com/v1alpha1"},
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey:     &imageRepository,
 				OwnerReferences: ownerReferences,
 			})
 			// wait for imagerepository_controller to finish
-			waitImageRepositoryFinalizerOnImageRepository_old(imageRepository)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(imageRepository)
 			// add generate annotation and it will not create new ImageRepository
 			setComponentAnnotationValue(resourceImageErrorKey, GenerateImageAnnotationName, `{"visibility": "public"}`)
 			waitComponentAnnotationGone(resourceImageErrorKey, GenerateImageAnnotationName)
 
-			component = getComponent(resourceImageErrorKey)
+			component = getComponentOldModel(resourceImageErrorKey)
 			Expect(component.Annotations[ImageAnnotationName]).To(BeEmpty())
 			// just to double check that new ImageRepository wasn't created, which would add ContainerImage
 			Expect(component.Spec.ContainerImage).To(BeEmpty())
@@ -281,7 +281,7 @@ var _ = Describe("Component image controller", func() {
 			Expect(k8sClient.List(ctx, imageRepositoriesList, &client.ListOptions{Namespace: resourceImageErrorKey.Namespace})).To(Succeed())
 			Expect(imageRepositoriesList.Items).To(HaveLen(1))
 
-			deleteImageRepository_old(imageRepository)
+			deleteImageRepositoryOldModel(imageRepository)
 		})
 
 		It("should do nothing and set error if generate annotation is invalid JSON", func() {
@@ -291,7 +291,7 @@ var _ = Describe("Component image controller", func() {
 			waitComponentAnnotation(resourceImageErrorKey, ImageAnnotationName)
 
 			repoImageInfo := &ImageRepositoryStatus{}
-			component := getComponent(resourceImageErrorKey)
+			component := getComponentOldModel(resourceImageErrorKey)
 			Expect(json.Unmarshal([]byte(component.Annotations[ImageAnnotationName]), repoImageInfo)).To(Succeed())
 			Expect(repoImageInfo.Message).To(ContainSubstring("invalid JSON"))
 
@@ -307,7 +307,7 @@ var _ = Describe("Component image controller", func() {
 			waitComponentAnnotation(resourceImageErrorKey, ImageAnnotationName)
 
 			repoImageInfo := &ImageRepositoryStatus{}
-			component := getComponent(resourceImageErrorKey)
+			component := getComponentOldModel(resourceImageErrorKey)
 			Expect(json.Unmarshal([]byte(component.Annotations[ImageAnnotationName]), repoImageInfo)).To(Succeed())
 			Expect(repoImageInfo.Message).To(ContainSubstring("invalid value: none in visibility field"))
 
@@ -317,7 +317,7 @@ var _ = Describe("Component image controller", func() {
 		})
 
 		It("should clean environment", func() {
-			deleteComponent(resourceImageErrorKey)
+			deleteComponentOldModel(resourceImageErrorKey)
 			deleteApplication(applicationKey)
 			deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: imageTestNamespace})
 			deleteServiceAccount(types.NamespacedName{Name: IntegrationServiceAccountName, Namespace: imageTestNamespace})

--- a/internal/controller/imagerepository_controller.go
+++ b/internal/controller/imagerepository_controller.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	irv1alpha1 "github.com/konflux-ci/image-controller/api/konflux/v1alpha1"
 	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1" // remove after fully migrated to new group
@@ -45,12 +46,21 @@ import (
 )
 
 const (
-	InternalSecretLabelName = "appstudio.redhat.com/internal"
+	ComponentNameLabelName  = "build.konflux-ci.dev/component"
+	InternalSecretLabelName = "konflux-ci.dev/internal" // #nosec G101
+	// remove after fully migrated to new group
+	InternalSecretLabelNameOldModel = "appstudio.redhat.com/internal"
 
-	ImageRepositoryFinalizer = "appstudio.openshift.io/image-repository"
+	ImageRepositoryFinalizer = "konflux-ci.dev/image-repository"
+	// remove after fully migrated to new group
+	ImageRepositoryFinalizerOldModel = "appstudio.openshift.io/image-repository"
 
-	updateComponentAnnotationName        = "image-controller.appstudio.redhat.com/update-component-image"
-	skipRepositoryDeletionAnnotationName = "image-controller.appstudio.redhat.com/skip-repository-deletion"
+	updateComponentAnnotationName = "build.konflux-ci.dev/update-component-image"
+	// remove after fully migrated to new group
+	updateComponentAnnotationNameOldModel = "image-controller.appstudio.redhat.com/update-component-image"
+	skipRepositoryDeletionAnnotationName  = "build.konflux-ci.dev/skip-repository-deletion"
+	// remove after fully migrated to new group
+	skipRepositoryDeletionAnnotationNameOldModel = "image-controller.appstudio.redhat.com/skip-repository-deletion"
 
 	waitForRelatedComponentInitialDelay           = 5
 	waitForRelatedComponentFallbackDelay          = 60
@@ -65,7 +75,9 @@ const (
 	namespacePullSecretName = "components-namespace-pull"
 	// when missing, will ensure namespace pull secret and namespace pull robot account and add the annotation
 	// when true, namespace pull secret and namespace pull robot account created
-	namespacePullSecretEnsuredAnnotation = "image-controller.appstudio.redhat.com/namespace-pull-secret-ensured"
+	namespacePullSecretEnsuredAnnotation = "build.konflux-ci.dev/namespace-pull-secret-ensured" // #nosec G101
+	// remove after fully migrated to new group
+	namespacePullSecretEnsuredAnnotationOldModel = "image-controller.appstudio.redhat.com/namespace-pull-secret-ensured"
 )
 
 // ImageRepositoryReconciler reconciles a ImageRepository object
@@ -226,7 +238,9 @@ func setMetricsTime(idForMetrics string, reconcileStartTime time.Time) {
 //+kubebuilder:rbac:groups=konflux-ci.dev,resources=imagerepositories,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=konflux-ci.dev,resources=imagerepositories/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=konflux-ci.dev,resources=imagerepositories/finalizers,verbs=update
-//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch
+// remove after fully migrated to new group
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=konflux-ci.dev,resources=components,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;update;patch
@@ -283,7 +297,7 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
-		if isComponentLinked(imageRepository) {
+		if isComponentLinked(imageRepository, r.IsOldGroup) {
 			pushSecretName := imageRepository.Status.Credentials.PushSecretName
 			if pushSecretName == "" {
 				// It should not happen unless status is edited not by the operator.
@@ -293,6 +307,10 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 			// unlink secret from component SA
 			componentSaName := getComponentSaName(imageRepository.Labels[ComponentNameLabelName])
+			// remove after fully migrated to new group
+			if r.IsOldGroup {
+				componentSaName = getComponentSaName(imageRepository.Labels[ComponentNameLabelNameOldModel])
+			}
 			if err := r.unlinkSecretFromServiceAccount(ctx, componentSaName, pushSecretName, imageRepository.Namespace); err != nil {
 				log.Error(err, "failed to unlink secret from service account", "SaName", componentSaName, "SecretName", pushSecretName, l.Action, l.ActionUpdate)
 				return ctrl.Result{}, err
@@ -326,9 +344,10 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// remove after fully migrated to new group - end
 		}
 
-		if controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer) {
+		// remove after fully migrated to new group
+		if controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizerOldModel) || controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer) {
 			// Check if there isn't other ImageRepository for the same repository from other component
-			imageName, imageRepositoryUrl := r.getQuayImageNameAndURL(imageRepository)
+			imageName, imageRepositoryUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 			imageRepositoryFound, err := r.ImageRepositoryForSameUrlExists(ctx, imageRepository, imageRepositoryUrl)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -338,7 +357,13 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				log.Info("Found another image repository for", "RepoURL", imageRepositoryUrl)
 			}
 
-			skipDeletion := imageRepository.Annotations[skipRepositoryDeletionAnnotationName] == "true"
+			var skipDeletion bool
+			// remove after fully migrated to new group
+			if !r.IsOldGroup {
+				skipDeletion = imageRepository.Annotations[skipRepositoryDeletionAnnotationName] == "true"
+			} else {
+				skipDeletion = imageRepository.Annotations[skipRepositoryDeletionAnnotationNameOldModel] == "true"
+			}
 			if skipDeletion {
 				log.Info("Skip deletion was configured for image repository", "ImageRepository", imageRepository.Name)
 			}
@@ -358,7 +383,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// Do not block deletion on failures
 			r.CleanupImageRepository(ctx, imageRepository, !(imageRepositoryFound || skipDeletion))
 
-			controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizer)
+			// remove after fully migrated to new group
+			if !r.IsOldGroup {
+				controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizer)
+			} else {
+				controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizerOldModel)
+			}
 			// remove after fully migrated to new group (uncomment line below and remove helper call)
 			// if err := r.Client.Update(ctx, imageRepository); err != nil
 			if err := r.updateImageRepository(ctx, imageRepository); err != nil {
@@ -384,7 +414,8 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if imageRepository.Status.State == irv1alpha1.ImageRepositoryStateDamaged ||
 		imageRepository.Status.State == irv1alpha1.ImageRepositoryStateMissing {
-		if controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer) {
+		// remove after fully migrated to new group
+		if controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizerOldModel) || controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer) {
 			// Do not perform any action on object which was damaged.
 			return ctrl.Result{}, nil
 		}
@@ -400,9 +431,10 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Provision image repository if it hasn't been done yet
-	if !controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer) {
+	// remove after fully migrated to new group
+	if !controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizerOldModel) && !controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer) {
 		setMetricsTime(repositoryIdForMetrics, reconcileStartTime)
-		if isComponentLinked(imageRepository) {
+		if isComponentLinked(imageRepository, r.IsOldGroup) {
 			componentExists, requeueAfterSeconds, err := r.CheckComponentExistence(ctx, imageRepository)
 			if err != nil {
 				// getting component failed
@@ -427,7 +459,7 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 	// Finalizer is present, image repository should exist.
-	imageNameInOrg, imageUrl := r.getQuayImageNameAndURL(imageRepository)
+	imageNameInOrg, imageUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 	// Check status fields and mark the object as damaged if status was lost.
 	s := imageRepository.Status
@@ -435,7 +467,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		s.Credentials.PushRobotAccountName == "" || s.Credentials.PullRobotAccountName == "" ||
 		s.Credentials.PushSecretName == "" || s.Credentials.PullSecretName == "" {
 		imageRepository.Status.State = irv1alpha1.ImageRepositoryStateDamaged
-		imageRepository.Status.Message = fmt.Sprintf("Object status was damaged. Remove %s finalizer to try to recover.", ImageRepositoryFinalizer)
+		// remove after fully migrated to new group
+		if !r.IsOldGroup {
+			imageRepository.Status.Message = fmt.Sprintf("Object status was damaged. Remove %s finalizer to try to recover.", ImageRepositoryFinalizer)
+		} else {
+			imageRepository.Status.Message = fmt.Sprintf("Object status was damaged. Remove %s finalizer to try to recover.", ImageRepositoryFinalizerOldModel)
+		}
 		// remove after fully migrated to new group (uncomment line below and remove helper call)
 		// if err = r.Client.Status().Update(ctx, imageRepository); err != nil
 		if err = r.updateImageRepositoryStatus(ctx, imageRepository); err != nil {
@@ -454,7 +491,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	if !repositoryExists {
 		imageRepository.Status.State = irv1alpha1.ImageRepositoryStateMissing
-		imageRepository.Status.Message = fmt.Sprintf("Image repository is missing. Remove %s finalizer to try to recover.", ImageRepositoryFinalizer)
+		// remove after fully migrated to new group
+		if !r.IsOldGroup {
+			imageRepository.Status.Message = fmt.Sprintf("Image repository is missing. Remove %s finalizer to try to recover.", ImageRepositoryFinalizer)
+		} else {
+			imageRepository.Status.Message = fmt.Sprintf("Image repository is missing. Remove %s finalizer to try to recover.", ImageRepositoryFinalizerOldModel)
+		}
 		// remove after fully migrated to new group (uncomment line below and remove helper call)
 		// if err = r.Client.Status().Update(ctx, imageRepository); err != nil
 		if err = r.updateImageRepositoryStatus(ctx, imageRepository); err != nil {
@@ -467,7 +509,13 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Now it's safe to proceed to other operations with image repository
 
 	// ensure that namespace pull secret and namespace pull robot account exist, and set annotation afterwards
-	_, namespacePullSecretEnsuredExists := imageRepository.Annotations[namespacePullSecretEnsuredAnnotation]
+	var namespacePullSecretEnsuredExists bool
+	// remove after fully migrated to new group
+	if !r.IsOldGroup {
+		_, namespacePullSecretEnsuredExists = imageRepository.Annotations[namespacePullSecretEnsuredAnnotation]
+	} else {
+		_, namespacePullSecretEnsuredExists = imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel]
+	}
 	if !namespacePullSecretEnsuredExists {
 		namespaceRobot, err := r.getOrCreateNamespaceRobot(ctx, imageRepository.Namespace)
 		if err != nil {
@@ -480,7 +528,12 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if imageRepository.Annotations == nil {
 			imageRepository.Annotations = make(map[string]string)
 		}
-		imageRepository.Annotations[namespacePullSecretEnsuredAnnotation] = "true"
+		// remove after fully migrated to new group
+		if !r.IsOldGroup {
+			imageRepository.Annotations[namespacePullSecretEnsuredAnnotation] = "true"
+		} else {
+			imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel] = "true"
+		}
 
 		// remove after fully migrated to new group (uncomment line below and remove helper call)
 		// if err := r.Client.Update(ctx, imageRepository); err != nil
@@ -495,7 +548,7 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Update component's containerImage and link push secret to component SA, add pull secret to application secret
 	// link namespace pull secret to integration and component SA
-	if isComponentLinked(imageRepository) {
+	if isComponentLinked(imageRepository, r.IsOldGroup) {
 		pullSecretName := getSecretName(imageRepository, true, r.IsOldGroup)
 		applicationName := imageRepository.Labels[ApplicationNameLabelName]
 
@@ -513,6 +566,10 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// link push secret to component SA
 		pushSecretName := getSecretName(imageRepository, false, r.IsOldGroup)
 		componentSaName := getComponentSaName(imageRepository.Labels[ComponentNameLabelName])
+		// remove after fully migrated to new group
+		if r.IsOldGroup {
+			componentSaName = getComponentSaName(imageRepository.Labels[ComponentNameLabelNameOldModel])
+		}
 		if err := r.linkSecretToServiceAccount(ctx, componentSaName, pushSecretName, imageRepository.Namespace, false, false); err != nil {
 			log.Error(err, "failed to link push secret to component service account", "SaName", componentSaName, "SecretName", pushSecretName, l.Action, l.ActionUpdate)
 			return ctrl.Result{}, err
@@ -530,29 +587,67 @@ func (r *ImageRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 
-		updateComponentAnnotation, updateComponentAnnotationExists := imageRepository.Annotations[updateComponentAnnotationName]
+		var updateComponentAnnotation string
+		var updateComponentAnnotationExists bool
+		// remove after fully migrated to new group
+		if !r.IsOldGroup {
+			updateComponentAnnotation, updateComponentAnnotationExists = imageRepository.Annotations[updateComponentAnnotationName]
+		} else {
+			updateComponentAnnotation, updateComponentAnnotationExists = imageRepository.Annotations[updateComponentAnnotationNameOldModel]
+		}
 		if updateComponentAnnotationExists && updateComponentAnnotation == "true" {
 			componentName := imageRepository.Labels[ComponentNameLabelName]
-			component := &compapiv1alpha1.Component{}
+			// remove after fully migrated to new group
+			if r.IsOldGroup {
+				componentName = imageRepository.Labels[ComponentNameLabelNameOldModel]
+			}
 			componentKey := types.NamespacedName{Namespace: imageRepository.Namespace, Name: componentName}
-			if err := r.Client.Get(ctx, componentKey, component); err != nil {
-				if errors.IsNotFound(err) {
-					log.Info("attempt to update non existing component", "ComponentName", componentName)
-					return ctrl.Result{}, nil
+
+			if !r.IsOldGroup {
+				component := &compv1alpha1.Component{}
+				if err := r.Client.Get(ctx, componentKey, component); err != nil {
+					if errors.IsNotFound(err) {
+						log.Info("attempt to update non existing component", "ComponentName", componentName)
+						return ctrl.Result{}, nil
+					}
+
+					log.Error(err, "failed to get component", "ComponentName", componentName, l.Action, l.ActionView)
+					return ctrl.Result{}, err
 				}
 
-				log.Error(err, "failed to get component", "ComponentName", componentName, l.Action, l.ActionView)
-				return ctrl.Result{}, err
-			}
+				component.Spec.ContainerImage = imageUrl
 
-			component.Spec.ContainerImage = imageUrl
+				if err := r.Client.Update(ctx, component); err != nil {
+					log.Error(err, "failed to update Component after provision", "ComponentName", componentName, l.Action, l.ActionUpdate)
+					return ctrl.Result{}, err
+				}
+			} else { // remove after fully migrated to new group - start
+				component := &compapiv1alpha1.Component{}
+				if err := r.Client.Get(ctx, componentKey, component); err != nil {
+					if errors.IsNotFound(err) {
+						log.Info("attempt to update non existing component", "ComponentName", componentName)
+						return ctrl.Result{}, nil
+					}
 
-			if err := r.Client.Update(ctx, component); err != nil {
-				log.Error(err, "failed to update Component after provision", "ComponentName", componentName, l.Action, l.ActionUpdate)
-				return ctrl.Result{}, err
-			}
+					log.Error(err, "failed to get component", "ComponentName", componentName, l.Action, l.ActionView)
+					return ctrl.Result{}, err
+				}
+
+				component.Spec.ContainerImage = imageUrl
+
+				if err := r.Client.Update(ctx, component); err != nil {
+					log.Error(err, "failed to update Component after provision", "ComponentName", componentName, l.Action, l.ActionUpdate)
+					return ctrl.Result{}, err
+				}
+			} // remove after fully migrated to new group - end
+
 			log.Info("Updated component's ContainerImage", "ComponentName", componentName)
-			delete(imageRepository.Annotations, updateComponentAnnotationName)
+			// remove after fully migrated to new group
+			if !r.IsOldGroup {
+				delete(imageRepository.Annotations, updateComponentAnnotationName)
+			} else {
+				delete(imageRepository.Annotations, updateComponentAnnotationNameOldModel)
+			}
 
 			// remove after fully migrated to new group (uncomment line below and remove helper call)
 			// if err := r.Client.Update(ctx, imageRepository); err != nil
@@ -669,8 +764,20 @@ func (r *ImageRepositoryReconciler) CheckComponentExistence(ctx context.Context,
 	log := ctrllog.FromContext(ctx).WithName("CheckComponentExistence")
 
 	componentName := imageRepository.Labels[ComponentNameLabelName]
-	component := &compapiv1alpha1.Component{}
+	// remove after fully migrated to new group
+	if r.IsOldGroup {
+		componentName = imageRepository.Labels[ComponentNameLabelNameOldModel]
+	}
 	componentKey := types.NamespacedName{Namespace: imageRepository.Namespace, Name: componentName}
+
+	// remove following block after fully migrated to new group - replace with: component := &compv1alpha1.Component{}
+	var component client.Object
+	if !r.IsOldGroup {
+		component = &compv1alpha1.Component{}
+	} else {
+		component = &compapiv1alpha1.Component{}
+	}
+
 	if err := r.Client.Get(ctx, componentKey, component); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("component related to image repository doesn't exist, will wait for component", "Component", componentName)
@@ -721,11 +828,22 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 	log := ctrllog.FromContext(ctx).WithName("ImageRepositoryProvision")
 	ctx = ctrllog.IntoContext(ctx, log)
 
-	var component *compapiv1alpha1.Component
-	if isComponentLinked(imageRepository) {
+	var component client.Object // remove after fully migrated to new group - replace with: var component *compv1alpha1.Component
+	if isComponentLinked(imageRepository, r.IsOldGroup) {
 		componentName := imageRepository.Labels[ComponentNameLabelName]
-		component = &compapiv1alpha1.Component{}
+		// remove after fully migrated to new group
+		if r.IsOldGroup {
+			componentName = imageRepository.Labels[ComponentNameLabelNameOldModel]
+		}
 		componentKey := types.NamespacedName{Namespace: imageRepository.Namespace, Name: componentName}
+
+		// remove following block after fully migrated to new group
+		if !r.IsOldGroup {
+			component = &compv1alpha1.Component{}
+		} else {
+			component = &compapiv1alpha1.Component{}
+		}
+
 		if err := r.Client.Get(ctx, componentKey, component); err != nil {
 			if errors.IsNotFound(err) {
 				log.Info("attempt to create image repository related to non existing component", "Component", componentName)
@@ -747,7 +865,7 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 		return err
 	}
 
-	imageRepositoryName, quayImageURL := r.getQuayImageNameAndURL(imageRepository)
+	imageRepositoryName, quayImageURL := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 	if imageRepository.Spec.Image.Name == "" {
 		imageRepository.Spec.Image.Name = imageRepositoryName
 	}
@@ -826,12 +944,18 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 	if imageRepository.Annotations == nil {
 		imageRepository.Annotations = make(map[string]string)
 	}
-	imageRepository.Annotations[namespacePullSecretEnsuredAnnotation] = "true"
 
-	controllerutil.AddFinalizer(imageRepository, ImageRepositoryFinalizer)
-	if isComponentLinked(imageRepository) {
+	// remove after fully migrated to new group
+	if !r.IsOldGroup {
+		imageRepository.Annotations[namespacePullSecretEnsuredAnnotation] = "true"
+		controllerutil.AddFinalizer(imageRepository, ImageRepositoryFinalizer)
+	} else {
+		imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel] = "true"
+		controllerutil.AddFinalizer(imageRepository, ImageRepositoryFinalizerOldModel)
+	}
+	if isComponentLinked(imageRepository, r.IsOldGroup) {
 		if err := controllerutil.SetOwnerReference(component, imageRepository, r.Scheme); err != nil {
-			log.Error(err, "failed to set component as owner", "ComponentName", component.Name)
+			log.Error(err, "failed to set component as owner", "ComponentName", component.GetName())
 			// Do not fail provision because of failed owner reference
 		}
 	}
@@ -859,7 +983,7 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepository(ctx context.Context
 // The function handles misconfigurations where possible.
 // It must be used to get image name instead of accessing spec.image.name which could have a wrong information.
 // Example return values: tenant/image, quay.io/org/tenant/image
-func (r *ImageRepositoryReconciler) getQuayImageNameAndURL(imageRepository *irv1alpha1.ImageRepository) (string, string) {
+func (r *ImageRepositoryReconciler) getQuayImageNameAndURL(imageRepository *irv1alpha1.ImageRepository, isOldGroup bool) (string, string) {
 	if imageRepository.Status.Image.URL != "" {
 		// It's possible to read the data from the status
 		imageURL := imageRepository.Status.Image.URL
@@ -877,8 +1001,12 @@ func (r *ImageRepositoryReconciler) getQuayImageNameAndURL(imageRepository *irv1
 
 	var imageRepositoryName string
 	if imageRepository.Spec.Image.Name == "" {
-		if isComponentLinked(imageRepository) {
+		if isComponentLinked(imageRepository, isOldGroup) {
 			componentName := imageRepository.Labels[ComponentNameLabelName]
+			// remove after fully migrated to new group
+			if isOldGroup {
+				componentName = imageRepository.Labels[ComponentNameLabelNameOldModel]
+			}
 			imageRepositoryName = imageRepository.Namespace + "/" + componentName
 		} else {
 			imageRepositoryName = imageRepository.Namespace + "/" + imageRepository.Name
@@ -904,7 +1032,7 @@ func (r *ImageRepositoryReconciler) ProvisionImageRepositoryAccess(ctx context.C
 	log := ctrllog.FromContext(ctx).WithName("ProvisionImageRepositoryAccess").WithValues("IsPullOnly", isPullOnly)
 	ctx = ctrllog.IntoContext(ctx, log)
 
-	imageName, imageUrl := r.getQuayImageNameAndURL(imageRepository)
+	imageName, imageUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 	var robotAccountName string
 	if isPullOnly {
@@ -1003,7 +1131,7 @@ func (r *ImageRepositoryReconciler) RegenerateImageRepositoryAccessToken(ctx con
 	log := ctrllog.FromContext(ctx).WithName("RegenerateImageRepositoryAccessToken").WithValues("IsPullOnly", isPullOnly)
 	ctx = ctrllog.IntoContext(ctx, log)
 
-	_, quayImageURL := r.getQuayImageNameAndURL(imageRepository)
+	_, quayImageURL := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 	robotAccountName := imageRepository.Status.Credentials.PushRobotAccountName
 	if isPullOnly {
@@ -1027,7 +1155,7 @@ func (r *ImageRepositoryReconciler) RegenerateImageRepositoryAccessToken(ctx con
 
 	// update also secret in application secret (old group only)
 	// remove after fully migrated to new group - start
-	if r.IsOldGroup && isComponentLinked(imageRepository) && isPullOnly {
+	if r.IsOldGroup && isComponentLinked(imageRepository, r.IsOldGroup) && isPullOnly {
 		applicationName := imageRepository.Labels[ApplicationNameLabelName]
 		if applicationName != "" {
 			err := r.addPullSecretAuthToApplicationPullSecret(ctx, applicationName, imageRepository.Namespace, secretName, quayImageURL, true)
@@ -1090,7 +1218,7 @@ func (r *ImageRepositoryReconciler) CleanupImageRepository(ctx context.Context, 
 		}
 	}
 
-	imageRepositoryName, imageRepositoryUrl := r.getQuayImageNameAndURL(imageRepository)
+	imageRepositoryName, imageRepositoryUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 	if !removeRepository {
 		log.Info("Skipping the removal of image repository", "RepoName", imageRepositoryUrl)
@@ -1113,7 +1241,7 @@ func (r *ImageRepositoryReconciler) ChangeImageRepositoryVisibility(ctx context.
 
 	log := ctrllog.FromContext(ctx)
 
-	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository)
+	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 	requestedVisibility := string(imageRepository.Spec.Image.Visibility)
 	err := r.QuayClient.ChangeRepositoryVisibility(r.QuayOrganization, imageRepositoryName, requestedVisibility)
 	if err == nil {
@@ -1177,6 +1305,12 @@ func (r *ImageRepositoryReconciler) EnsureSecret(ctx context.Context, imageRepos
 			},
 			Type:       corev1.SecretTypeDockerConfigJson,
 			StringData: generateDockerconfigSecretData(imageURL, robotAccount),
+		}
+		// remove after fully migrated to new group
+		if r.IsOldGroup {
+			secret.ObjectMeta.Labels = map[string]string{
+				InternalSecretLabelNameOldModel: "true",
+			}
 		}
 
 		if setOwnership {
@@ -1274,8 +1408,12 @@ func getSecretName(imageRepository *irv1alpha1.ImageRepository, isPullOnly bool,
 	return secretName
 }
 
-func isComponentLinked(imageRepository *irv1alpha1.ImageRepository) bool {
-	return imageRepository.Labels[ComponentNameLabelName] != ""
+func isComponentLinked(imageRepository *irv1alpha1.ImageRepository, isOldGroup bool) bool {
+	// remove after fully migrated to new group
+	if !isOldGroup {
+		return imageRepository.Labels[ComponentNameLabelName] != ""
+	}
+	return imageRepository.Labels[ComponentNameLabelNameOldModel] != ""
 }
 
 func getRandomString(length int) string {
@@ -1319,7 +1457,7 @@ func (r *ImageRepositoryReconciler) ImageRepositoryForSameUrlExists(ctx context.
 	}
 
 	for _, imageRepo := range imageRepositoriesList.Items {
-		_, imageRepoUrl := r.getQuayImageNameAndURL(&imageRepo)
+		_, imageRepoUrl := r.getQuayImageNameAndURL(&imageRepo, false)
 		if imageRepositoryUrl == imageRepoUrl {
 			// Skipping the original ImageRepository which is in the list as well
 			// Skip only if same name AND we're processing from the new group
@@ -1341,7 +1479,7 @@ func (r *ImageRepositoryReconciler) ImageRepositoryForSameUrlExists(ctx context.
 	for _, imageRepo := range imageRepositoriesListOldGroup.Items {
 		imageRepoConverted := convertAppstudioToKonflux(&imageRepo)
 		if imageRepoConverted != nil {
-			_, imageRepoUrl := r.getQuayImageNameAndURL(imageRepoConverted)
+			_, imageRepoUrl := r.getQuayImageNameAndURL(imageRepoConverted, true)
 			if imageRepositoryUrl == imageRepoUrl {
 				// Skip only if same name AND we're processing from the old group
 				if imageRepositoryName == imageRepo.ObjectMeta.Name && r.IsOldGroup {
@@ -1524,7 +1662,7 @@ func (r *ImageRepositoryReconciler) removePullSecretFromApplicationPullSecret(ct
 		return err
 	}
 
-	_, imageRepositoryUrl := r.getQuayImageNameAndURL(imageRepository)
+	_, imageRepositoryUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 	changed := false
 	for reg := range toRemoveAuths.Auths {
@@ -1550,7 +1688,7 @@ func (r *ImageRepositoryReconciler) removePullSecretFromApplicationPullSecret(ct
 			if otherIRConverted == nil {
 				continue
 			}
-			_, otherIrImageUrl := r.getQuayImageNameAndURL(otherIRConverted)
+			_, otherIrImageUrl := r.getQuayImageNameAndURL(otherIRConverted, r.IsOldGroup)
 			if otherIrImageUrl != imageRepositoryUrl {
 				continue
 			}
@@ -1627,7 +1765,7 @@ func (r *ImageRepositoryReconciler) ensureNamespacePullSecret(ctx context.Contex
 		return err
 	}
 
-	imageName, _ := r.getQuayImageNameAndURL(imageRepository)
+	imageName, _ := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 	if err := r.QuayClient.AddPermissionsForRepositoryToAccount(r.QuayOrganization, imageName, namespaceRobot.Name, true, false); err != nil {
 		return err
 	}

--- a/internal/controller/imagerepository_controller_old_test.go
+++ b/internal/controller/imagerepository_controller_old_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return nil, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{ResourceKey: &resourceKey})
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ResourceKey: &resourceKey})
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isCreatePullRobotAccountInvoked }, timeout, interval).Should(BeTrue())
@@ -157,11 +157,11 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isAddPullPermissionsToAccountInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isAddPullPermissionsToNamespaceAccountInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Annotations).To(HaveLen(1))
-			Expect(imageRepository.Annotations[namespacePullSecretEnsuredAnnotation]).To(Equal("true"))
+			Expect(imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel]).To(Equal("true"))
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 			Expect(imageRepository.Spec.Image.Visibility).To(Equal(imagerepositoryv1alpha1.ImageVisibilityPublic))
 			Expect(imageRepository.OwnerReferences).To(BeEmpty())
@@ -180,17 +180,17 @@ var _ = Describe("Image repository controller (old group)", func() {
 			pushSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PushSecretName, Namespace: imageRepository.Namespace}
 			pushSecret := waitSecretExist(pushSecretKey)
 			defer deleteSecret(pushSecretKey)
-			verifySecretSpec(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
+			verifySecretSpecOldModel(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
 
 			pullSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}
 			pullSecret := waitSecretExist(pullSecretKey)
 			defer deleteSecret(pullSecretKey)
-			verifySecretSpec(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
+			verifySecretSpecOldModel(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: imageRepository.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
 			defer deleteSecret(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 
 			pushSecretDockerconfigJson := string(pushSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(pushSecretDockerconfigJson, expectedImage, imageRepository.Status.Credentials.PushRobotAccountName, pushToken)
@@ -221,7 +221,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.RobotAccount{Name: robotName, Token: newPushToken}, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			oldTokenGenerationTimestamp := *imageRepository.Status.Credentials.GenerationTimestamp
 			regenerateToken := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{RegenerateToken: &regenerateToken}
@@ -230,7 +230,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isRegenerateRobotAccountTokenForPullInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isRegenerateRobotAccountTokenForPushInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Credentials.RegenerateToken == nil &&
 					imageRepository.Status.Credentials.GenerationTimestamp != nil &&
 					*imageRepository.Status.Credentials.GenerationTimestamp != oldTokenGenerationTimestamp
@@ -238,13 +238,13 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			pushSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PushSecretName, Namespace: imageRepository.Namespace}
 			pushSecret := waitSecretExist(pushSecretKey)
-			verifySecretSpec(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
+			verifySecretSpecOldModel(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
 			pushSecretDockerconfigJson := string(pushSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(pushSecretDockerconfigJson, expectedImage, imageRepository.Status.Credentials.PushRobotAccountName, newPushToken)
 
 			pullSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}
 			pullSecret := waitSecretExist(pullSecretKey)
-			verifySecretSpec(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
+			verifySecretSpecOldModel(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
 			pullSecretDockerconfigJson := string(pullSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(pullSecretDockerconfigJson, expectedImage, imageRepository.Status.Credentials.PullRobotAccountName, newPullToken)
 		})
@@ -261,20 +261,20 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.RobotAccount{Name: robotName, Token: newNamespaceToken}, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			regenerateToken := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{RegenerateNamespacePullToken: &regenerateToken}
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isRegenerateNamespaceRobotAccountTokenInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Credentials.RegenerateNamespacePullToken == nil
 			}, timeout, interval).Should(BeTrue())
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: imageRepository.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, newNamespaceToken)
 		})
@@ -290,13 +290,13 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Image.Visibility = imagerepositoryv1alpha1.ImageVisibilityPrivate
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isChangeRepositoryVisibilityInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Image.Visibility == imagerepositoryv1alpha1.ImageVisibilityPrivate &&
 					imageRepository.Status.Image.Visibility == imagerepositoryv1alpha1.ImageVisibilityPrivate &&
 					imageRepository.Status.Message == ""
@@ -304,23 +304,23 @@ var _ = Describe("Image repository controller (old group)", func() {
 		})
 
 		It("should add message when image name was edited", func() {
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Image.Name = "renamed"
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return strings.HasPrefix(imageRepository.Status.Message, imageRepositoryNameChangedMessagePrefix)
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("should remove message when image name is the same again", func() {
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Image.Name = expectedImageName
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Status.Message == ""
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -359,14 +359,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// remove namespace pull secret ensured annotation to force new reconcile and simulate old IR
-			imageRepository := getImageRepository_old(resourceKey)
-			delete(imageRepository.Annotations, namespacePullSecretEnsuredAnnotation)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
+			delete(imageRepository.Annotations, namespacePullSecretEnsuredAnnotationOldModel)
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			// Wait for the annotation to be set to true
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
-				return imageRepository.Annotations[namespacePullSecretEnsuredAnnotation] == "true"
+				imageRepository := getImageRepositoryOldModel(resourceKey)
+				return imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel] == "true"
 			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool { return isGetRobotAccountInvoked }, timeout, interval).Should(BeTrue())
@@ -374,7 +374,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isAddPullPermissionsToNamespaceAccountInvoked }, timeout, interval).Should(BeTrue())
 
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, namespaceRobotTokenRefreshed1)
 		})
@@ -415,7 +415,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return isDeleteRobotAccountForPullInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isDeleteRobotAccountForPushInvoked }, timeout, interval).Should(BeTrue())
@@ -425,7 +425,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: resourceKey.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, namespaceRobotTokenRefreshed1)
 		})
@@ -444,13 +444,13 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			quay.ResetTestQuayClientToFails()
 			quay.RepositoryExistsFunc = func(organization, imageRepository string) (bool, error) { return true, nil }
-			// Use _old helpers that default to defaultNamespaceOld
-			createApplication_old(applicationConfig{})
-			createComponent_old(componentConfig{ComponentApplication: defaultComponentApplication})
+			// Use OldModel helpers that default to defaultNamespaceOld
+			createApplicationOldModel(applicationConfig{})
+			createComponentOldModel(componentConfig{ComponentApplication: defaultComponentApplication})
 		})
 
 		AfterEach(func() {
-			deleteComponent(componentKey)
+			deleteComponentOldModel(componentKey)
 			deleteApplication(applicationKey)
 		})
 
@@ -573,11 +573,11 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return nil
 			}
 
-			imageRepositoryConfigObject := imageRepositoryConfig_old{
+			imageRepositoryConfigObject := imageRepositoryConfigOldModel{
 				ResourceKey: &resourceKey,
 				Labels: map[string]string{
-					ApplicationNameLabelName: defaultComponentApplication,
-					ComponentNameLabelName:   defaultComponentName,
+					ApplicationNameLabelName:       defaultComponentApplication,
+					ComponentNameLabelNameOldModel: defaultComponentName,
 				},
 			}
 			if setNotification {
@@ -594,10 +594,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			if updateComponentAnnotation {
-				imageRepositoryConfigObject.Annotations = map[string]string{updateComponentAnnotationName: "true"}
+				imageRepositoryConfigObject.Annotations = map[string]string{updateComponentAnnotationNameOldModel: "true"}
 			}
 
-			createImageRepository_old(imageRepositoryConfigObject)
+			createImageRepositoryOldModel(imageRepositoryConfigObject)
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isCreatePushRobotAccountInvoked }, timeout, interval).Should(BeTrue())
@@ -611,10 +611,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 			Eventually(func() bool { return isGetRobotAccountInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			component := getComponent(componentKey)
-			imageRepository := getImageRepository_old(resourceKey)
+			component := getComponentOldModel(componentKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 
 			if setNotification {
 				Eventually(func() bool { return isGetNotificationsInvoked }, timeout, interval).Should(BeTrue())
@@ -625,7 +625,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				Expect(component.Spec.ContainerImage).To(BeEmpty())
 			}
 			Expect(imageRepository.Annotations).To(HaveLen(1))
-			Expect(imageRepository.Annotations[namespacePullSecretEnsuredAnnotation]).To(Equal("true"))
+			Expect(imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel]).To(Equal("true"))
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 			Expect(imageRepository.Spec.Image.Visibility).To(Equal(imagerepositoryv1alpha1.ImageVisibilityPublic))
 			Expect(imageRepository.OwnerReferences).To(HaveLen(1))
@@ -653,22 +653,22 @@ var _ = Describe("Image repository controller (old group)", func() {
 			pushSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PushSecretName, Namespace: imageRepository.Namespace}
 			pushSecret := waitSecretExist(pushSecretKey)
 			defer deleteSecret(pushSecretKey)
-			verifySecretSpec(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
+			verifySecretSpecOldModel(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
 
 			pullSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}
 			pullSecret := waitSecretExist(pullSecretKey)
 			defer deleteSecret(pullSecretKey)
-			verifySecretSpec(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
+			verifySecretSpecOldModel(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
 
 			applicationSecretKey := types.NamespacedName{Name: applicationSecretName, Namespace: imageRepository.Namespace}
 			applicationSecret := waitSecretExist(applicationSecretKey)
 			defer deleteSecret(applicationSecretKey)
-			verifySecretSpec(applicationSecret, "Application", applicationGroupVersion, applicationKey.Name, applicationSecretName)
+			verifySecretSpecOldModel(applicationSecret, "Application", applicationGroupVersion, applicationKey.Name, applicationSecretName)
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: imageRepository.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
 			defer deleteSecret(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 
 			pushSecretDockerconfigJson := string(pushSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(pushSecretDockerconfigJson, expectedImage, imageRepository.Status.Credentials.PushRobotAccountName, pushToken)
@@ -717,7 +717,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			assertSecretsGoneFromServiceAccounts()
 		})
 
@@ -734,11 +734,11 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// Remove all status fields
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Status = imagerepositoryv1alpha1.ImageRepositoryStatus{}
 			Expect(k8sClient.Status().Update(ctx, imageRepository)).To(Succeed())
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			assertSecretsGoneFromServiceAccounts()
 		})
 
@@ -747,7 +747,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			// it is possible to fully recover missing info and do full cleanup.
 			assertProvisionRepository(false, false)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			pushRobotAccountName := imageRepository.Status.Credentials.PushRobotAccountName
 			pullRobotAccountName := imageRepository.Status.Credentials.PullRobotAccountName
 
@@ -776,7 +776,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			imageRepository.Status.Credentials.PullRobotAccountName = pullRobotAccountName
 			Expect(k8sClient.Status().Update(ctx, imageRepository)).To(Succeed())
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			assertSecretsGoneFromServiceAccounts()
 			Eventually(func() bool { return isPushRobotAccountDeleted }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isPullRobotAccountDeleted }, timeout, interval).Should(BeTrue())
@@ -810,7 +810,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.RobotAccount{Name: robotName, Token: newPushToken}, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			oldTokenGenerationTimestamp := *imageRepository.Status.Credentials.GenerationTimestamp
 			regenerateToken := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{RegenerateToken: &regenerateToken}
@@ -819,7 +819,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isRegenerateRobotAccountTokenForPushInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isRegenerateRobotAccountTokenForPullInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Credentials.RegenerateToken == nil &&
 					imageRepository.Status.Credentials.GenerationTimestamp != nil &&
 					*imageRepository.Status.Credentials.GenerationTimestamp != oldTokenGenerationTimestamp
@@ -827,15 +827,15 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			pushSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PushSecretName, Namespace: imageRepository.Namespace}
 			pushSecret := waitSecretExist(pushSecretKey)
-			verifySecretSpec(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
+			verifySecretSpecOldModel(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
 
 			pullSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}
 			pullSecret := waitSecretExist(pullSecretKey)
-			verifySecretSpec(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
+			verifySecretSpecOldModel(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
 
 			applicationSecretKey := types.NamespacedName{Name: applicationSecretName, Namespace: imageRepository.Namespace}
 			applicationSecret := waitSecretExist(applicationSecretKey)
-			verifySecretSpec(applicationSecret, "Application", applicationGroupVersion, imageRepository.Labels[ApplicationNameLabelName], applicationSecretName)
+			verifySecretSpecOldModel(applicationSecret, "Application", applicationGroupVersion, imageRepository.Labels[ApplicationNameLabelName], applicationSecretName)
 
 			pushSecretDockerconfigJson := string(pushSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(pushSecretDockerconfigJson, expectedImage, imageRepository.Status.Credentials.PushRobotAccountName, newPushToken)
@@ -871,7 +871,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.RobotAccount{Name: robotName, Token: newPushToken}, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			oldTokenGenerationTimestamp := *imageRepository.Status.Credentials.GenerationTimestamp
 			regenerateToken := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{RegenerateToken: &regenerateToken}
@@ -880,7 +880,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isRegenerateRobotAccountTokenForPushInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isRegenerateRobotAccountTokenForPullInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Credentials.RegenerateToken == nil &&
 					imageRepository.Status.Credentials.GenerationTimestamp != nil &&
 					*imageRepository.Status.Credentials.GenerationTimestamp != oldTokenGenerationTimestamp
@@ -888,15 +888,15 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			pushSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PushSecretName, Namespace: imageRepository.Namespace}
 			pushSecret := waitSecretExist(pushSecretKey)
-			verifySecretSpec(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
+			verifySecretSpecOldModel(pushSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pushSecret.Name)
 
 			pullSecretKey := types.NamespacedName{Name: imageRepository.Status.Credentials.PullSecretName, Namespace: imageRepository.Namespace}
 			pullSecret := waitSecretExist(pullSecretKey)
-			verifySecretSpec(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
+			verifySecretSpecOldModel(pullSecret, "ImageRepository", imagerepositoryv1alpha1.GroupVersion.String(), imageRepository.GetName(), pullSecret.Name)
 
 			applicationSecretKey := types.NamespacedName{Name: applicationSecretName, Namespace: imageRepository.Namespace}
 			applicationSecret := waitSecretExist(applicationSecretKey)
-			verifySecretSpec(applicationSecret, "Application", applicationGroupVersion, imageRepository.Labels[ApplicationNameLabelName], applicationSecretName)
+			verifySecretSpecOldModel(applicationSecret, "Application", applicationGroupVersion, imageRepository.Labels[ApplicationNameLabelName], applicationSecretName)
 
 			pushSecretDockerconfigJson := string(pushSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(pushSecretDockerconfigJson, expectedImage, imageRepository.Status.Credentials.PushRobotAccountName, newPushToken)
@@ -920,20 +920,20 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.RobotAccount{Name: robotName, Token: newNamespaceToken}, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			regenerateToken := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{RegenerateNamespacePullToken: &regenerateToken}
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isRegenerateNamespaceRobotAccountTokenInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Credentials.RegenerateNamespacePullToken == nil
 			}, timeout, interval).Should(BeTrue())
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: imageRepository.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, newNamespaceToken)
 		})
@@ -950,20 +950,20 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.RobotAccount{Name: robotName, Token: newNamespaceToken}, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			regenerateToken := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{RegenerateNamespacePullToken: &regenerateToken}
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isRegenerateNamespaceRobotAccountTokenInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Credentials.RegenerateNamespacePullToken == nil
 			}, timeout, interval).Should(BeTrue())
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: imageRepository.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, newNamespaceToken)
 		})
@@ -981,12 +981,12 @@ var _ = Describe("Image repository controller (old group)", func() {
 			componentSa.Secrets = []corev1.ObjectReference{}
 			Expect(k8sClient.Update(ctx, &componentSa)).To(Succeed())
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			verifyLinking := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{VerifyLinking: &verifyLinking}
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
-			waitImageRepositoryCredentialSectionRequestGone_old(resourceKey, "verify")
+			waitImageRepositoryCredentialSectionRequestGoneOldModel(resourceKey, "verify")
 
 			pushSecretName := fmt.Sprintf("%s-image-push", resourceKey.Name)
 			integrationSa = getServiceAccount(defaultNamespaceOld, IntegrationServiceAccountName)
@@ -1018,12 +1018,12 @@ var _ = Describe("Image repository controller (old group)", func() {
 			componentSa.ImagePullSecrets = []corev1.LocalObjectReference{{Name: pushSecretName}, {Name: pushSecretName}}
 			Expect(k8sClient.Update(ctx, &componentSa)).To(Succeed())
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			verifyLinking := true
 			imageRepository.Spec.Credentials = &imagerepositoryv1alpha1.ImageCredentials{VerifyLinking: &verifyLinking}
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
-			waitImageRepositoryCredentialSectionRequestGone_old(resourceKey, "verify")
+			waitImageRepositoryCredentialSectionRequestGoneOldModel(resourceKey, "verify")
 
 			applicationSa = getServiceAccount(defaultNamespaceOld, IntegrationServiceAccountName)
 			componentSa = getServiceAccount(defaultNamespaceOld, componentSaName)
@@ -1075,14 +1075,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 			componentSaName := getComponentSaName(defaultComponentName)
 
 			// remove namespace pull secret ensured annotation to force new reconcile and simulate old IR
-			imageRepository := getImageRepository_old(resourceKey)
-			delete(imageRepository.Annotations, namespacePullSecretEnsuredAnnotation)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
+			delete(imageRepository.Annotations, namespacePullSecretEnsuredAnnotationOldModel)
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			// Wait for the annotation to be set to true
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
-				return imageRepository.Annotations[namespacePullSecretEnsuredAnnotation] == "true"
+				imageRepository := getImageRepositoryOldModel(resourceKey)
+				return imageRepository.Annotations[namespacePullSecretEnsuredAnnotationOldModel] == "true"
 			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool { return isGetRobotAccountInvoked }, timeout, interval).Should(BeTrue())
@@ -1090,7 +1090,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isAddPullPermissionsToNamespaceAccountInvoked }, timeout, interval).Should(BeTrue())
 
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, namespaceRobotTokenRefreshed2)
 
@@ -1137,7 +1137,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return isDeleteRobotAccountForPushInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isDeleteRobotAccountForPullInvoked }, timeout, interval).Should(BeTrue())
@@ -1152,7 +1152,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			namespaceSecretKey := types.NamespacedName{Name: namespacePullSecretName, Namespace: resourceKey.Namespace}
 			namespaceSecret := waitSecretExist(namespaceSecretKey)
-			verifySecretSpec(namespaceSecret, "", "", "", namespacePullSecretName)
+			verifySecretSpecOldModel(namespaceSecret, "", "", "", namespacePullSecretName)
 			namespaceSecretDockerconfigJson := string(namespaceSecret.Data[corev1.DockerConfigJsonKey])
 			verifySecretAuth(namespaceSecretDockerconfigJson, expectedNamespaceImage, expectedNamespaceRobotAccountName, namespaceRobotTokenRefreshed2)
 
@@ -1189,16 +1189,16 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey:   &resourceKey,
 				Notifications: []imagerepositoryv1alpha1.Notifications{},
 			})
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 			Expect(imageRepository.Spec.Image.Visibility).To(Equal(imagerepositoryv1alpha1.ImageVisibilityPublic))
 			Expect(imageRepository.OwnerReferences).To(BeEmpty())
@@ -1245,14 +1245,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 					Url: "http://test-url",
 				},
 			}
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Notifications = append(imageRepository.Spec.Notifications, newNotification)
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isCreateNotificationInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isGetNotificationsInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return len(imageRepository.Status.Notifications) == 1
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -1290,14 +1290,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 				}
 				return notifications, nil
 			}
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Notifications[0].Config.Url = updatedUrl
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isUpdateNotificationInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isGetNotificationsInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return len(imageRepository.Status.Notifications) == 1 && imageRepository.Spec.Notifications[0].Config.Url == updatedUrl && imageRepository.Status.Notifications[0].UUID == "uuid_new"
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -1328,7 +1328,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return notifications, nil
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Status.Notifications).To(HaveLen(1))
 			imageRepository.Spec.Notifications = imageRepository.Spec.Notifications[:len(imageRepository.Spec.Notifications)-1]
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
@@ -1336,20 +1336,20 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isDeleteNotificationInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isGetNotificationsInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return len(imageRepository.Status.Notifications) == 0
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("should provision image repository with some notifications to create", func() {
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			isCreateNotificationInvoked := false
 			quay.CreateNotificationFunc = func(organization, repository string, notification quay.Notification) (*quay.Notification, error) {
 				isCreateNotificationInvoked = true
 				Expect(organization).To(Equal(quay.TestQuayOrg))
 				return &quay.Notification{UUID: "uuid"}, nil
 			}
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey: &resourceKey,
 				Notifications: []imagerepositoryv1alpha1.Notifications{
 					{
@@ -1372,16 +1372,16 @@ var _ = Describe("Image repository controller (old group)", func() {
 			})
 			Eventually(func() bool { return isCreateNotificationInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Status.Notifications).To(HaveLen(2))
 			Expect(imageRepository.Status.Notifications[0].Title).To(Equal("test-notification"))
 			Expect(imageRepository.Status.Notifications[1].Title).To(Equal("test-notification-2"))
 		})
 
 		It("should clean environment", func() {
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 		})
 	})
 
@@ -1390,7 +1390,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 		})
 
 		It("should create image repository with requested name", func() {
@@ -1409,14 +1409,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{ImageName: customImageName, ResourceKey: &resourceKey})
-			defer deleteImageRepository_old(resourceKey)
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ImageName: customImageName, ResourceKey: &resourceKey})
+			defer deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Spec.Image.Name).To(Equal(customImageName))
 			Expect(imageRepository.Status.Image.URL).To(Equal(expectedStatusImageName))
 		})
@@ -1436,14 +1436,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{ImageName: customImageName, ResourceKey: &resourceKey})
-			defer deleteImageRepository_old(resourceKey)
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ImageName: customImageName, ResourceKey: &resourceKey})
+			defer deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 		})
 
@@ -1461,20 +1461,20 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{ImageName: customImageName, ResourceKey: &resourceKey})
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ImageName: customImageName, ResourceKey: &resourceKey})
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
 			anotherImageRepositoryKey := types.NamespacedName{Name: defaultImageRepositoryName + "-other2", Namespace: defaultNamespaceOld}
 			isCreateRepositoryInvoked = false
 
-			createImageRepository_old(imageRepositoryConfig_old{ImageName: customImageName, ResourceKey: &anotherImageRepositoryKey})
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ImageName: customImageName, ResourceKey: &anotherImageRepositoryKey})
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryFinalizerOnImageRepository_old(anotherImageRepositoryKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(anotherImageRepositoryKey)
 
-			imageRepository1 := getImageRepository_old(resourceKey)
+			imageRepository1 := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository1.Spec.Image.Name).To(Equal(expectedImageName))
-			imageRepository2 := getImageRepository_old(anotherImageRepositoryKey)
+			imageRepository2 := getImageRepositoryOldModel(anotherImageRepositoryKey)
 			Expect(imageRepository2.Spec.Image.Name).To(Equal(expectedImageName))
 			Expect(imageRepository1.Status.Image.URL).To(Equal(imageRepository2.Status.Image.URL))
 
@@ -1494,10 +1494,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			// should not delete repository, because it is used by other ImageRepository
 			Eventually(func() bool { return isDeleteRobotAccountInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryGone_old(resourceKey)
+			waitImageRepositoryGoneOldModel(resourceKey)
 
 			isDeleteRepositoryInvoked := false
 			quay.DeleteRepositoryFunc = func(organization, imageRepository string) (bool, error) {
@@ -1509,7 +1509,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			isDeleteRobotAccountInvoked = false
-			deleteImageRepository_old(anotherImageRepositoryKey)
+			deleteImageRepositoryOldModel(anotherImageRepositoryKey)
 			// should delete repository, because no other ImageRepository uses the repository
 			Eventually(func() bool { return isDeleteRobotAccountInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isDeleteRepositoryInvoked }, timeout, interval).Should(BeTrue())
@@ -1530,9 +1530,9 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// Create OLD group ImageRepository
-			createImageRepository_old(imageRepositoryConfig_old{ImageName: customImageName, ResourceKey: &resourceKey})
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ImageName: customImageName, ResourceKey: &resourceKey})
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
 			// Create NEW group ImageRepository with same image name in SAME namespace (typical migration scenario)
 			newGroupImageRepositoryKey := types.NamespacedName{Name: defaultImageRepositoryName + "-new-group", Namespace: defaultNamespaceOld}
@@ -1542,7 +1542,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 			waitImageRepositoryFinalizerOnImageRepository(newGroupImageRepositoryKey)
 
-			imageRepositoryOld := getImageRepository_old(resourceKey)
+			imageRepositoryOld := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepositoryOld.Spec.Image.Name).To(Equal(expectedImageName))
 			imageRepositoryNew := getImageRepository(newGroupImageRepositoryKey)
 			Expect(imageRepositoryNew.Spec.Image.Name).To(Equal(expectedImageName))
@@ -1565,10 +1565,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// Delete OLD group ImageRepository
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			// should NOT delete Quay repository, because NEW group ImageRepository still uses it
 			Eventually(func() bool { return isDeleteRobotAccountInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryGone_old(resourceKey)
+			waitImageRepositoryGoneOldModel(resourceKey)
 
 			// Now delete NEW group ImageRepository
 			isDeleteRepositoryInvoked := false
@@ -1605,15 +1605,15 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// create imageRepository without component
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey: &resourceKey,
 				ImageName:   customImageName,
 			})
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			nudgingImageRepository := getImageRepository_old(resourceKey)
+			nudgingImageRepository := getImageRepositoryOldModel(resourceKey)
 			nudgedPullSecretName := nudgingImageRepository.Status.Credentials.PullSecretName
 			commonPullSecretName := "common-pull-secret"
 			commonPushSecretName := "common-push-secret"
@@ -1657,7 +1657,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			Eventually(func() bool { return isDeleteRobotAccountInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isDeleteRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
@@ -1683,10 +1683,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 			applicationKey := types.NamespacedName{Name: "nudging-application", Namespace: defaultNamespaceOld}
 			componentKey := types.NamespacedName{Name: "nudging-component", Namespace: defaultNamespaceOld}
 			componentSaName := getComponentSaName(componentKey.Name)
-			createApplication_old(applicationConfig{ApplicationKey: applicationKey})
-			createComponent_old(componentConfig{ComponentKey: componentKey, ComponentApplication: defaultComponentApplication})
+			createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
+			createComponentOldModel(componentConfig{ComponentKey: componentKey, ComponentApplication: defaultComponentApplication})
 			createServiceAccount(defaultNamespaceOld, componentSaName)
-			defer deleteComponent(componentKey)
+			defer deleteComponentOldModel(componentKey)
 			defer deleteApplication(applicationKey)
 			defer deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: defaultNamespaceOld})
 
@@ -1704,19 +1704,19 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// create imageRepository for component
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey: &resourceKey,
 				ImageName:   customImageName,
 				Labels: map[string]string{
-					ApplicationNameLabelName: applicationKey.Name,
-					ComponentNameLabelName:   componentKey.Name,
+					ApplicationNameLabelName:       applicationKey.Name,
+					ComponentNameLabelNameOldModel: componentKey.Name,
 				},
 			})
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			nudgingImageRepository := getImageRepository_old(resourceKey)
+			nudgingImageRepository := getImageRepositoryOldModel(resourceKey)
 			nudgedPullSecretName := nudgingImageRepository.Status.Credentials.PullSecretName
 			commonPullSecretName := "common-pull-secret"
 			commonPushSecretName := "common-push-secret"
@@ -1760,7 +1760,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			Eventually(func() bool { return isDeleteRobotAccountInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isDeleteRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
@@ -1802,14 +1802,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{ResourceKey: &resourceKey})
-			defer deleteImageRepository_old(resourceKey)
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ResourceKey: &resourceKey})
+			defer deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return createRepositoryInvocationCount == 3 }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 		})
 
@@ -1817,10 +1817,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 			applicationKey := types.NamespacedName{Name: defaultComponentApplication, Namespace: defaultNamespaceOld}
 			componentKey := types.NamespacedName{Name: defaultComponentName, Namespace: defaultNamespaceOld}
 			componentSaName := getComponentSaName(componentKey.Name)
-			createApplication_old(applicationConfig{ApplicationKey: applicationKey})
-			createComponent_old(componentConfig{ComponentKey: componentKey, ComponentApplication: defaultComponentApplication})
+			createApplicationOldModel(applicationConfig{ApplicationKey: applicationKey})
+			createComponentOldModel(componentConfig{ComponentKey: componentKey, ComponentApplication: defaultComponentApplication})
 			createServiceAccount(defaultNamespaceOld, componentSaName)
-			defer deleteComponent(componentKey)
+			defer deleteComponentOldModel(componentKey)
 			defer deleteApplication(applicationKey)
 			defer deleteServiceAccount(types.NamespacedName{Name: componentSaName, Namespace: defaultNamespaceOld})
 
@@ -1847,11 +1847,11 @@ var _ = Describe("Image repository controller (old group)", func() {
 			quay.CreateNotificationFunc = func(organization, repository string, notification quay.Notification) (*quay.Notification, error) {
 				return prepareNotificationResponse(notification), nil
 			}
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey: &resourceKey,
 				Labels: map[string]string{
-					ApplicationNameLabelName: defaultComponentApplication,
-					ComponentNameLabelName:   defaultComponentName,
+					ApplicationNameLabelName:       defaultComponentApplication,
+					ComponentNameLabelNameOldModel: defaultComponentName,
 				},
 				Notifications: []imagerepositoryv1alpha1.Notifications{
 					{
@@ -1868,14 +1868,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 					},
 				},
 			})
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
 			// Update image name in spec and wait status update
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Image.Name = "renamed"
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 			Eventually(func() bool {
-				imageRepository = getImageRepository_old(resourceKey)
+				imageRepository = getImageRepositoryOldModel(resourceKey)
 				return strings.HasPrefix(imageRepository.Status.Message, imageRepositoryNameChangedMessagePrefix)
 			}, timeout, interval).Should(BeTrue())
 
@@ -1947,11 +1947,11 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			imageRepository = getImageRepository_old(resourceKey)
+			imageRepository = getImageRepositoryOldModel(resourceKey)
 			// update component image scenario
-			imageRepository.Annotations[updateComponentAnnotationName] = "true"
+			imageRepository.Annotations[updateComponentAnnotationNameOldModel] = "true"
 			// ensure namespace pull secret scenario
-			delete(imageRepository.Annotations, namespacePullSecretEnsuredAnnotation)
+			delete(imageRepository.Annotations, namespacePullSecretEnsuredAnnotationOldModel)
 			// change visibility scenario
 			imageRepository.Spec.Image.Visibility = imagerepositoryv1alpha1.ImageVisibilityPrivate
 			// notifications scenarios
@@ -1976,7 +1976,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 			Eventually(func() bool { return isAddPermissionsForRepositoryToAccountInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isChangeRepositoryVisibilityInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				component := getComponent(componentKey)
+				component := getComponentOldModel(componentKey)
 				return component.Spec.ContainerImage == imageRepository.Status.Image.URL
 			}, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isGetNotificationsInvoked }, timeout, interval).Should(BeTrue())
@@ -2000,7 +2000,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return isRemovePermissionsForRepositoryFromAccountInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool { return isDeleteRepositoryInvoked }, timeout, interval).Should(BeTrue())
@@ -2019,14 +2019,14 @@ var _ = Describe("Image repository controller (old group)", func() {
 				Expect(repository.Description).ToNot(BeEmpty())
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
-			createImageRepository_old(imageRepositoryConfig_old{ResourceKey: &resourceKey})
-			defer deleteImageRepository_old(resourceKey)
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ResourceKey: &resourceKey})
+			defer deleteImageRepositoryOldModel(resourceKey)
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
 			// Check that the image repository was provisioned successfully
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
-			imageRepository := getImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Status.State).To(Equal(imagerepositoryv1alpha1.ImageRepositoryStateReady))
 			Expect(imageRepository.Status.Message).To(BeEmpty())
 
@@ -2040,7 +2040,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return false, nil
 			}
 			// Make a change to trigger a reconcile
-			imageRepository = getImageRepository_old(resourceKey)
+			imageRepository = getImageRepositoryOldModel(resourceKey)
 			imageRepository.ObjectMeta.Annotations["new-reconcile"] = "true"
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
@@ -2048,7 +2048,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			// Wait status updated with state missing and corresponding error message
 			Eventually(func() bool {
-				imageRepository = getImageRepository_old(resourceKey)
+				imageRepository = getImageRepositoryOldModel(resourceKey)
 				isStateMissing := imageRepository.Status.State == imagerepositoryv1alpha1.ImageRepositoryStateMissing
 				isErrorMessageSet := imageRepository.Status.Message != "" && strings.Contains(imageRepository.Status.Message, "Image repository is missing")
 				return isStateMissing && isErrorMessageSet
@@ -2071,13 +2071,13 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// Request recover by removing finalizer
-			Expect(controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizer)).To(BeTrue())
+			Expect(controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizerOldModel)).To(BeTrue())
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
-			imageRepository = getImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
+			imageRepository = getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Status.State).To(Equal(imagerepositoryv1alpha1.ImageRepositoryStateReady))
 			Expect(imageRepository.Status.Message).To(BeEmpty())
 		})
@@ -2100,13 +2100,13 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{ResourceKey: &resourceKey})
-			defer deleteImageRepository_old(resourceKey)
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ResourceKey: &resourceKey})
+			defer deleteImageRepositoryOldModel(resourceKey)
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 			Expect(isCreateRepositoryInvoked).To(BeTrue())
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 			Expect(imageRepository.Status.State).To(Equal(imagerepositoryv1alpha1.ImageRepositoryStateReady))
 			Expect(imageRepository.Status.Message).To(BeEmpty())
@@ -2126,7 +2126,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 			// Wait status updated with state damaged and corresponding error message
 			Eventually(func() bool {
-				imageRepository = getImageRepository_old(resourceKey)
+				imageRepository = getImageRepositoryOldModel(resourceKey)
 				isStateDamaged := imageRepository.Status.State == imagerepositoryv1alpha1.ImageRepositoryStateDamaged
 				isErrorMessageSet := imageRepository.Status.Message != "" && strings.Contains(imageRepository.Status.Message, "status was damaged")
 				return isStateDamaged && isErrorMessageSet
@@ -2194,11 +2194,11 @@ var _ = Describe("Image repository controller (old group)", func() {
 			}
 
 			// Request recover by removing finalizer
-			Expect(controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizer)).To(BeTrue())
+			Expect(controllerutil.RemoveFinalizer(imageRepository, ImageRepositoryFinalizerOldModel)).To(BeTrue())
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
-			imageRepository = getImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
+			imageRepository = getImageRepositoryOldModel(resourceKey)
 
 			Expect(createRobotAccountInvokedTimes).To(Equal(2))
 			Expect(newPushRobotAccountName).ToNot(BeEmpty())
@@ -2229,7 +2229,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 		})
 
 		It("don't remove repository if explicitly requested using annotation", func() {
@@ -2246,15 +2246,15 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return &quay.Repository{Name: expectedImageName}, nil
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ImageName:   customImageName,
 				ResourceKey: &resourceKey,
-				Annotations: map[string]string{skipRepositoryDeletionAnnotationName: "true"},
+				Annotations: map[string]string{skipRepositoryDeletionAnnotationNameOldModel: "true"},
 			})
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			Expect(imageRepository.Spec.Image.Name).To(Equal(expectedImageName))
 
 			isDeleteRobotAccountInvoked := false
@@ -2272,7 +2272,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return true, nil
 			}
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 			// should not delete repository, because of the annotation
 			Expect(isDeleteRobotAccountInvoked).To(BeTrue())
 			Expect(isDeleteRepositoryInvoked).To(BeFalse())
@@ -2284,7 +2284,7 @@ var _ = Describe("Image repository controller (old group)", func() {
 
 		BeforeEach(func() {
 			quay.ResetTestQuayClient()
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 		})
 
 		It("should prepare environment", func() {
@@ -2306,20 +2306,20 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return nil, fmt.Errorf("payment required")
 			}
 
-			createImageRepository_old(imageRepositoryConfig_old{Visibility: "private", ResourceKey: &resourceKey})
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{Visibility: "private", ResourceKey: &resourceKey})
 
 			Eventually(func() bool { return isCreateRepositoryInvoked }, timeout, interval).Should(BeTrue())
 
 			imageRepository := &imagerepositoryv1alpha1.ImageRepository{}
 			Eventually(func() bool {
-				imageRepository = getImageRepository_old(resourceKey)
+				imageRepository = getImageRepositoryOldModel(resourceKey)
 				return string(imageRepository.Status.State) != ""
 			}, timeout, interval).Should(BeTrue())
 			Expect(imageRepository.Status.State).To(Equal(imagerepositoryv1alpha1.ImageRepositoryStateFailed))
 			Expect(imageRepository.Status.Message).ToNot(BeEmpty())
 			Expect(imageRepository.Status.Message).To(ContainSubstring("exceeds current quay plan limit"))
 
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 		})
 
 		It("should add error message and revert visibility in spec if private visibility requested after provision but quota exceeded", func() {
@@ -2331,10 +2331,10 @@ var _ = Describe("Image repository controller (old group)", func() {
 			quay.CreateRobotAccountFunc = func(organization, robotName string) (*quay.RobotAccount, error) {
 				return &quay.RobotAccount{Name: robotName, Token: pushToken}, nil
 			}
-			createImageRepository_old(imageRepositoryConfig_old{ResourceKey: &resourceKey})
-			defer deleteImageRepository_old(resourceKey)
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{ResourceKey: &resourceKey})
+			defer deleteImageRepositoryOldModel(resourceKey)
 
-			waitImageRepositoryFinalizerOnImageRepository_old(resourceKey)
+			waitImageRepositoryFinalizerOnImageRepositoryOldModel(resourceKey)
 
 			quay.ResetTestQuayClientToFails()
 			quay.RepositoryExistsFunc = func(organization, imageRepository string) (bool, error) { return true, nil }
@@ -2349,44 +2349,44 @@ var _ = Describe("Image repository controller (old group)", func() {
 				return fmt.Errorf("payment required")
 			}
 
-			imageRepository := getImageRepository_old(resourceKey)
+			imageRepository := getImageRepositoryOldModel(resourceKey)
 			imageRepository.Spec.Image.Visibility = imagerepositoryv1alpha1.ImageVisibilityPrivate
 			Expect(k8sClient.Update(ctx, imageRepository)).To(Succeed())
 
 			Eventually(func() bool { return isChangeRepositoryVisibilityInvoked }, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Spec.Image.Visibility == imagerepositoryv1alpha1.ImageVisibilityPublic &&
 					imageRepository.Status.Image.Visibility == imagerepositoryv1alpha1.ImageVisibilityPublic &&
 					imageRepository.Status.Message != ""
 			}, timeout, interval).Should(BeTrue())
 
 			quay.ResetTestQuayClient()
-			deleteImageRepository_old(resourceKey)
+			deleteImageRepositoryOldModel(resourceKey)
 		})
 
 		It("should fail if invalid image repository linked by annotation to unexisting component", func() {
 			quay.ResetTestQuayClientToFails()
 
-			createImageRepository_old(imageRepositoryConfig_old{
+			createImageRepositoryOldModel(imageRepositoryConfigOldModel{
 				ResourceKey: &resourceKey,
 				ImageName:   fmt.Sprintf("%s/%s", defaultComponentApplication, defaultComponentName),
 				Labels: map[string]string{
-					ApplicationNameLabelName: defaultComponentApplication,
-					ComponentNameLabelName:   defaultComponentName,
+					ApplicationNameLabelName:       defaultComponentApplication,
+					ComponentNameLabelNameOldModel: defaultComponentName,
 				},
 			})
-			defer deleteImageRepository_old(resourceKey)
+			defer deleteImageRepositoryOldModel(resourceKey)
 
 			errorMessage := fmt.Sprintf("Component '%s' does not exist", defaultComponentName)
 			Eventually(func() bool {
-				imageRepository := getImageRepository_old(resourceKey)
+				imageRepository := getImageRepositoryOldModel(resourceKey)
 				return imageRepository.Status.Message == errorMessage
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("should fail if invalid image repository name given", func() {
-			imageRepository := getImageRepositoryConfig_old(imageRepositoryConfig_old{
+			imageRepository := getImageRepositoryConfigOldModel(imageRepositoryConfigOldModel{
 				ImageName: "wrong&name",
 			})
 			Expect(k8sClient.Create(ctx, imageRepository)).ToNot(Succeed())

--- a/internal/controller/imagerepository_controller_service_account.go
+++ b/internal/controller/imagerepository_controller_service_account.go
@@ -244,11 +244,16 @@ func (r *ImageRepositoryReconciler) VerifyAndFixSecretsLinking(ctx context.Conte
 	log := ctrllog.FromContext(ctx)
 
 	componentSaName := getComponentSaName(imageRepository.Labels[ComponentNameLabelName])
+	// remove after fully migrated to new group
+	if r.IsOldGroup {
+		componentSaName = getComponentSaName(imageRepository.Labels[ComponentNameLabelNameOldModel])
+	}
+
 	pushSecretName := imageRepository.Status.Credentials.PushSecretName
 	applicationName := imageRepository.Labels[ApplicationNameLabelName]
 	applicationPullSecretName := getApplicationPullSecretName(applicationName)
 
-	if isComponentLinked(imageRepository) {
+	if isComponentLinked(imageRepository, r.IsOldGroup) {
 		// link secret to component service account if isn't linked already
 		if err := r.linkSecretToServiceAccount(ctx, componentSaName, pushSecretName, imageRepository.Namespace, false, false); err != nil {
 			log.Error(err, "failed to link secret to component service account", "saName", componentSaName, "SecretName", pushSecretName, l.Action, l.ActionUpdate)

--- a/internal/controller/imagerepository_controller_unit_test.go
+++ b/internal/controller/imagerepository_controller_unit_test.go
@@ -281,7 +281,66 @@ func TestIsComponentLinked(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isComponentLinked(tc.imageRepository)
+			got := isComponentLinked(tc.imageRepository, false)
+
+			if got != tc.expect {
+				t.Errorf("isComponentLinked() for %v: expected %t but got %t", tc.imageRepository, tc.expect, got)
+			}
+		})
+	}
+}
+
+// remove after fully migrated to new group
+func TestIsComponentLinkedOldModel(t *testing.T) {
+	testCases := []struct {
+		name            string
+		imageRepository *irv1alpha1.ImageRepository
+		expect          bool
+	}{
+		{
+			name: "Should recognize linked component",
+			imageRepository: &irv1alpha1.ImageRepository{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						ApplicationNameLabelName:       "application-name",
+						ComponentNameLabelNameOldModel: "component-name",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name:            "Should not be linked to component if labels missing",
+			imageRepository: &irv1alpha1.ImageRepository{},
+			expect:          false,
+		},
+		{
+			name: "Should be linked to component even if application label missing",
+			imageRepository: &irv1alpha1.ImageRepository{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						ComponentNameLabelNameOldModel: "component-name",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "Should not be linked to component if component label missing",
+			imageRepository: &irv1alpha1.ImageRepository{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						ApplicationNameLabelName: "application-name",
+					},
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isComponentLinked(tc.imageRepository, true)
 
 			if got != tc.expect {
 				t.Errorf("isComponentLinked() for %v: expected %t but got %t", tc.imageRepository, tc.expect, got)
@@ -327,6 +386,7 @@ func TestGetQuayImageNameAndURL(t *testing.T) {
 	r := ImageRepositoryReconciler{
 		QuayHost:         "registry.org",
 		QuayOrganization: "my-org",
+		IsOldGroup:       false,
 	}
 
 	testCases := []struct {
@@ -406,7 +466,138 @@ func TestGetQuayImageNameAndURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			imageRepository := getTestImageRepo(tc.imageRepoConfig)
 
-			imageName, imageUrl := r.getQuayImageNameAndURL(imageRepository)
+			imageName, imageUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
+
+			if imageName != tc.expectedImageName {
+				t.Errorf("getQuayImageNameAndURL() got %s image name, but expected %s", imageName, tc.expectedImageName)
+			}
+			expectedImageUrl := fmt.Sprintf("%s/%s/%s", r.QuayHost, r.QuayOrganization, imageName)
+			if imageUrl != expectedImageUrl {
+				t.Errorf("getQuayImageNameAndURL() got %s image url, but expected %s", imageUrl, expectedImageUrl)
+			}
+		})
+	}
+}
+
+// remove after fully migrated to new group
+func TestGetQuayImageNameAndURLOldModel(t *testing.T) {
+	type imageRepositoryConfig struct {
+		SpecName          string
+		StatusImageUrl    string
+		IsComponentLinked bool
+	}
+	const crName = "my-image"
+	const namespace = "my-namespace"
+	const componentName = "my-component"
+	getTestImageRepo := func(config imageRepositoryConfig) *irv1alpha1.ImageRepository {
+		imageRepo := &irv1alpha1.ImageRepository{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      crName,
+				Namespace: namespace,
+			},
+			Spec: irv1alpha1.ImageRepositorySpec{
+				Image: irv1alpha1.ImageParameters{
+					Name: config.SpecName,
+				},
+			},
+			Status: irv1alpha1.ImageRepositoryStatus{
+				Image: irv1alpha1.ImageStatus{
+					URL: config.StatusImageUrl,
+				},
+			},
+		}
+		if config.IsComponentLinked {
+			imageRepo.ObjectMeta.Labels = map[string]string{
+				ComponentNameLabelNameOldModel: componentName,
+			}
+		}
+		return imageRepo
+	}
+
+	r := ImageRepositoryReconciler{
+		QuayHost:         "registry.org",
+		QuayOrganization: "my-org",
+		IsOldGroup:       true,
+	}
+
+	testCases := []struct {
+		name              string
+		imageRepoConfig   imageRepositoryConfig
+		expectedImageName string
+		// expectedImageUrl is always registry.domain/org/ + expectedImageName, so calculate it in the test
+	}{
+		{
+			name:              "Should generate default image name based on ImageRepository object name",
+			imageRepoConfig:   imageRepositoryConfig{},
+			expectedImageName: fmt.Sprintf("%s/%s", namespace, crName),
+		},
+		{
+			name:              "Should generate default image name based on ImageRepository object name and Component name",
+			imageRepoConfig:   imageRepositoryConfig{IsComponentLinked: true},
+			expectedImageName: fmt.Sprintf("%s/%s", namespace, componentName),
+		},
+		{
+			name:              "Should generate image name based on name in spec, name doesn't include namespace",
+			imageRepoConfig:   imageRepositoryConfig{SpecName: "custom-name"},
+			expectedImageName: fmt.Sprintf("%s/custom-name", namespace),
+		},
+		{
+			name:              "Should generate image name based on name in spec, name includes namespace",
+			imageRepoConfig:   imageRepositoryConfig{SpecName: fmt.Sprintf("%s/custom-name", namespace)},
+			expectedImageName: fmt.Sprintf("%s/custom-name", namespace),
+		},
+		{
+			name:              "Should generate image name based on name in spec, name has slash prefix",
+			imageRepoConfig:   imageRepositoryConfig{SpecName: "/custom/name"},
+			expectedImageName: fmt.Sprintf("%s/custom/name", namespace),
+		},
+		{
+			name: "Should get image name from image url in status",
+			imageRepoConfig: imageRepositoryConfig{
+				SpecName:       "name-in-spec",
+				StatusImageUrl: fmt.Sprintf("%s/%s/%s/name-in-status", r.QuayHost, r.QuayOrganization, namespace),
+			},
+			expectedImageName: fmt.Sprintf("%s/name-in-status", namespace),
+		},
+		{
+			name: "Should ignore image url in status if it attempts to reference another namespace (tenant)",
+			imageRepoConfig: imageRepositoryConfig{
+				SpecName:       "name-in-spec",
+				StatusImageUrl: fmt.Sprintf("%s/%s/not-owned-namespace/name-in-status", r.QuayHost, r.QuayOrganization),
+			},
+			expectedImageName: fmt.Sprintf("%s/name-in-spec", namespace),
+		},
+		{
+			name: "Should ignore image url in status if it attempts to reference another organization",
+			imageRepoConfig: imageRepositoryConfig{
+				SpecName:       "name-in-spec",
+				StatusImageUrl: fmt.Sprintf("%s/not-owned-org/%s/name-in-status", r.QuayHost, namespace),
+			},
+			expectedImageName: fmt.Sprintf("%s/name-in-spec", namespace),
+		},
+		{
+			name: "Should ignore image url in status if it attempts to reference another registry",
+			imageRepoConfig: imageRepositoryConfig{
+				SpecName:       "name-in-spec",
+				StatusImageUrl: fmt.Sprintf("another-registry.io/%s/%s/name-in-status", r.QuayOrganization, namespace),
+			},
+			expectedImageName: fmt.Sprintf("%s/name-in-spec", namespace),
+		},
+		{
+			name: "Should ignore name in spec if it was changed and status has correct image url",
+			imageRepoConfig: imageRepositoryConfig{
+				SpecName:       "new-name",
+				StatusImageUrl: fmt.Sprintf("%s/%s/%s/name-at-creation", r.QuayHost, r.QuayOrganization, namespace),
+			},
+			expectedImageName: fmt.Sprintf("%s/name-at-creation", namespace),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			imageRepository := getTestImageRepo(tc.imageRepoConfig)
+
+			imageName, imageUrl := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 			if imageName != tc.expectedImageName {
 				t.Errorf("getQuayImageNameAndURL() got %s image name, but expected %s", imageName, tc.expectedImageName)

--- a/internal/controller/imagerepository_notifications.go
+++ b/internal/controller/imagerepository_notifications.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (r *ImageRepositoryReconciler) AddNotification(notification irv1alpha1.Notifications, imageRepository *irv1alpha1.ImageRepository) (irv1alpha1.NotificationStatus, error) {
-	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository)
+	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 
 	notificationStatus := irv1alpha1.NotificationStatus{}
 	quayNotification, err := r.QuayClient.CreateNotification(
@@ -62,7 +62,7 @@ func (r *ImageRepositoryReconciler) HandleNotifications(ctx context.Context, ima
 		// No status notifications to check
 		return nil
 	}
-	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository)
+	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 	allNotifications, err := r.QuayClient.GetNotifications(r.QuayOrganization, imageRepositoryName)
 	if err != nil {
 		return r.handleError(ctx, imageRepository, err, "Couldn't retrieve all Quay notifications")
@@ -188,7 +188,7 @@ func (r *ImageRepositoryReconciler) SetNotifications(ctx context.Context, imageR
 
 func (r *ImageRepositoryReconciler) notificationExistsInQuayByUUID(uuid string, imageRepository *irv1alpha1.ImageRepository) (quay.Notification, error) {
 	notification := quay.Notification{}
-	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository)
+	imageRepositoryName, _ := r.getQuayImageNameAndURL(imageRepository, r.IsOldGroup)
 	allNotifications, err := r.QuayClient.GetNotifications(r.QuayOrganization, imageRepositoryName)
 	if err != nil {
 		return notification, err

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -36,6 +36,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
 	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	irv1alpha1 "github.com/konflux-ci/image-controller/api/konflux/v1alpha1"
 	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1" // remove after fully migrated to new group
@@ -69,7 +70,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	applicationApiDepVersion := "v0.0.0-20260529131129-a9594acdc104"
+	applicationApiDepVersion := "v0.0.0-20260727123715-2999a91451c6"
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
@@ -88,6 +89,9 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = compapiv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = compv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = irv1alpha1.AddToScheme(scheme.Scheme)

--- a/internal/controller/suite_util_test.go
+++ b/internal/controller/suite_util_test.go
@@ -32,7 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	compv1alpha1 "github.com/konflux-ci/application-api/api/konflux/v1alpha1"
+	compapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1" // remove after fully migrated to new group
 	irv1alpha1 "github.com/konflux-ci/image-controller/api/konflux/v1alpha1"
 	imagerepositoryv1alpha1 "github.com/konflux-ci/image-controller/api/v1alpha1" // remove after fully migrated to new group
 )
@@ -58,6 +59,7 @@ const (
 
 	defaultComponentName        = "test-component"
 	defaultComponentApplication = "test-application"
+	defaultSampleRepoLink       = "https://github.com/test-component/test-repo"
 )
 
 type imageRepositoryConfig struct {
@@ -72,7 +74,7 @@ type imageRepositoryConfig struct {
 }
 
 // remove after fully migrated to new group - entire type
-type imageRepositoryConfig_old struct {
+type imageRepositoryConfigOldModel struct {
 	ResourceKey     *types.NamespacedName
 	ImageName       string
 	Visibility      string
@@ -125,7 +127,7 @@ func getImageRepositoryConfig(config imageRepositoryConfig) *irv1alpha1.ImageRep
 }
 
 // remove after fully migrated to new group
-func getImageRepositoryConfig_old(config imageRepositoryConfig_old) *imagerepositoryv1alpha1.ImageRepository {
+func getImageRepositoryConfigOldModel(config imageRepositoryConfigOldModel) *imagerepositoryv1alpha1.ImageRepository {
 	name := defaultImageRepositoryName
 	namespace := defaultNamespace
 	if config.ResourceKey != nil {
@@ -175,12 +177,12 @@ func createImageRepository(config imageRepositoryConfig) *irv1alpha1.ImageReposi
 }
 
 // remove after fully migrated to new group
-func createImageRepository_old(config imageRepositoryConfig_old) *imagerepositoryv1alpha1.ImageRepository {
-	imageRepository := getImageRepositoryConfig_old(config)
+func createImageRepositoryOldModel(config imageRepositoryConfigOldModel) *imagerepositoryv1alpha1.ImageRepository {
+	imageRepository := getImageRepositoryConfigOldModel(config)
 	Expect(k8sClient.Create(ctx, imageRepository)).To(Succeed())
 
 	imageRepositoryKey := types.NamespacedName{Namespace: imageRepository.Namespace, Name: imageRepository.Name}
-	return getImageRepository_old(imageRepositoryKey)
+	return getImageRepositoryOldModel(imageRepositoryKey)
 }
 
 func getImageRepository(imageRepositoryKey types.NamespacedName) *irv1alpha1.ImageRepository {
@@ -193,7 +195,7 @@ func getImageRepository(imageRepositoryKey types.NamespacedName) *irv1alpha1.Ima
 }
 
 // remove after fully migrated to new group
-func getImageRepository_old(imageRepositoryKey types.NamespacedName) *imagerepositoryv1alpha1.ImageRepository {
+func getImageRepositoryOldModel(imageRepositoryKey types.NamespacedName) *imagerepositoryv1alpha1.ImageRepository {
 	imageRepository := &imagerepositoryv1alpha1.ImageRepository{}
 	Eventually(func() bool {
 		Expect(k8sClient.Get(ctx, imageRepositoryKey, imageRepository)).Should(Succeed())
@@ -215,7 +217,7 @@ func deleteImageRepository(imageRepositoryKey types.NamespacedName) {
 }
 
 // remove after fully migrated to new group
-func deleteImageRepository_old(imageRepositoryKey types.NamespacedName) {
+func deleteImageRepositoryOldModel(imageRepositoryKey types.NamespacedName) {
 	imageRepository := &imagerepositoryv1alpha1.ImageRepository{}
 	if err := k8sClient.Get(ctx, imageRepositoryKey, imageRepository); err != nil {
 		if k8sErrors.IsNotFound(err) {
@@ -224,7 +226,7 @@ func deleteImageRepository_old(imageRepositoryKey types.NamespacedName) {
 		Fail("Failed to get image repository")
 	}
 	Expect(k8sClient.Delete(ctx, imageRepository)).To(Succeed())
-	waitImageRepositoryGone_old(imageRepositoryKey)
+	waitImageRepositoryGoneOldModel(imageRepositoryKey)
 }
 
 func waitImageRepositoryGone(resourceKey types.NamespacedName) {
@@ -235,7 +237,7 @@ func waitImageRepositoryGone(resourceKey types.NamespacedName) {
 }
 
 // remove after fully migrated to new group
-func waitImageRepositoryGone_old(resourceKey types.NamespacedName) {
+func waitImageRepositoryGoneOldModel(resourceKey types.NamespacedName) {
 	imageRepository := &imagerepositoryv1alpha1.ImageRepository{}
 	Eventually(func() bool {
 		return k8sErrors.IsNotFound(k8sClient.Get(ctx, resourceKey, imageRepository))
@@ -247,7 +249,7 @@ type applicationConfig struct {
 }
 
 // remove after fully migrated to new group
-func getSampleApplicationData_old(config applicationConfig) *compapiv1alpha1.Application {
+func getSampleApplicationDataOldModel(config applicationConfig) *compapiv1alpha1.Application {
 	name := config.ApplicationKey.Name
 	if name == "" {
 		name = defaultComponentApplication
@@ -270,8 +272,8 @@ func getSampleApplicationData_old(config applicationConfig) *compapiv1alpha1.App
 }
 
 // remove after fully migrated to new group
-func createApplication_old(config applicationConfig) *compapiv1alpha1.Application {
-	application := getSampleApplicationData_old(config)
+func createApplicationOldModel(config applicationConfig) *compapiv1alpha1.Application {
+	application := getSampleApplicationDataOldModel(config)
 
 	Expect(k8sClient.Create(ctx, application)).Should(Succeed())
 
@@ -307,12 +309,14 @@ func deleteApplication(applicationKey types.NamespacedName) {
 }
 
 type componentConfig struct {
-	ComponentKey         types.NamespacedName
+	ComponentKey types.NamespacedName
+	// remove after fully migrated to new group
 	ComponentApplication string
-	Annotations          map[string]string
+	// remove after fully migrated to new group
+	Annotations map[string]string
 }
 
-func getSampleComponentData(config componentConfig) *compapiv1alpha1.Component {
+func getSampleComponentData(config componentConfig) *compv1alpha1.Component {
 	name := config.ComponentKey.Name
 	if name == "" {
 		name = defaultComponentName
@@ -321,31 +325,26 @@ func getSampleComponentData(config componentConfig) *compapiv1alpha1.Component {
 	if namespace == "" {
 		namespace = defaultNamespace
 	}
-	application := config.ComponentApplication
-	annotations := make(map[string]string)
-	if config.Annotations != nil {
-		annotations = config.Annotations
-	}
 
-	return &compapiv1alpha1.Component{
+	return &compv1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "appstudio.redhat.com/v1alpha1",
+			APIVersion: "konflux-ci.dev/v1alpha1",
 			Kind:       "Component",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
 		},
-		Spec: compapiv1alpha1.ComponentSpec{
-			ComponentName: name,
-			Application:   application,
+		Spec: compv1alpha1.ComponentSpec{
+			Source: compv1alpha1.ComponentSource{
+				GitURL: defaultSampleRepoLink + "-" + name,
+			},
 		},
 	}
 }
 
 // remove after fully migrated to new group
-func getSampleComponentData_old(config componentConfig) *compapiv1alpha1.Component {
+func getSampleComponentDataOldModel(config componentConfig) *compapiv1alpha1.Component {
 	name := config.ComponentKey.Name
 	if name == "" {
 		name = defaultComponentName
@@ -378,7 +377,7 @@ func getSampleComponentData_old(config componentConfig) *compapiv1alpha1.Compone
 }
 
 // createComponent creates sample component resource and verifies it was properly created.
-func createComponent(config componentConfig) *compapiv1alpha1.Component {
+func createComponent(config componentConfig) *compv1alpha1.Component {
 	component := getSampleComponentData(config)
 
 	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
@@ -388,16 +387,26 @@ func createComponent(config componentConfig) *compapiv1alpha1.Component {
 }
 
 // remove after fully migrated to new group
-func createComponent_old(config componentConfig) *compapiv1alpha1.Component {
-	component := getSampleComponentData_old(config)
+func createComponentOldModel(config componentConfig) *compapiv1alpha1.Component {
+	component := getSampleComponentDataOldModel(config)
 
 	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
 
 	componentKey := types.NamespacedName{Namespace: component.Namespace, Name: component.Name}
-	return getComponent(componentKey)
+	return getComponentOldModel(componentKey)
 }
 
-func getComponent(componentKey types.NamespacedName) *compapiv1alpha1.Component {
+func getComponent(componentKey types.NamespacedName) *compv1alpha1.Component {
+	component := &compv1alpha1.Component{}
+	Eventually(func() bool {
+		Expect(k8sClient.Get(ctx, componentKey, component)).Should(Succeed())
+		return component.ResourceVersion != ""
+	}, timeout, interval).Should(BeTrue())
+	return component
+}
+
+// remove after fully migrated to new group
+func getComponentOldModel(componentKey types.NamespacedName) *compapiv1alpha1.Component {
 	component := &compapiv1alpha1.Component{}
 	Eventually(func() bool {
 		Expect(k8sClient.Get(ctx, componentKey, component)).Should(Succeed())
@@ -408,6 +417,25 @@ func getComponent(componentKey types.NamespacedName) *compapiv1alpha1.Component 
 
 // deleteComponent deletes the specified component resource and verifies it was properly deleted
 func deleteComponent(componentKey types.NamespacedName) {
+	component := &compv1alpha1.Component{}
+
+	// Check if the component exists
+	if err := k8sClient.Get(ctx, componentKey, component); k8sErrors.IsNotFound(err) {
+		return
+	}
+
+	// Delete
+	Expect(k8sClient.Delete(ctx, component)).To(Succeed())
+
+	// Wait for delete to finish
+	Eventually(func() bool {
+		return k8sErrors.IsNotFound(k8sClient.Get(ctx, componentKey, component))
+	}, timeout, interval).Should(BeTrue())
+}
+
+// deleteComponent deletes the specified component resource and verifies it was properly deleted
+// remove after fully migrated to new group
+func deleteComponentOldModel(componentKey types.NamespacedName) {
 	component := &compapiv1alpha1.Component{}
 
 	// Check if the component exists
@@ -425,7 +453,7 @@ func deleteComponent(componentKey types.NamespacedName) {
 }
 
 func setComponentAnnotationValue(componentKey types.NamespacedName, annotationName string, annotationValue string) {
-	component := getComponent(componentKey)
+	component := getComponentOldModel(componentKey)
 	if component.Annotations == nil {
 		component.Annotations = make(map[string]string)
 	}
@@ -435,7 +463,7 @@ func setComponentAnnotationValue(componentKey types.NamespacedName, annotationNa
 
 func waitComponentAnnotation(componentKey types.NamespacedName, annotationName string) {
 	Eventually(func() bool {
-		component := getComponent(componentKey)
+		component := getComponentOldModel(componentKey)
 		annotations := component.GetAnnotations()
 		if annotations == nil {
 			return false
@@ -447,7 +475,7 @@ func waitComponentAnnotation(componentKey types.NamespacedName, annotationName s
 
 func waitComponentAnnotationGone(componentKey types.NamespacedName, annotationName string) {
 	Eventually(func() bool {
-		component := getComponent(componentKey)
+		component := getComponentOldModel(componentKey)
 		annotations := component.GetAnnotations()
 		if annotations == nil {
 			return true
@@ -468,13 +496,13 @@ func waitImageRepositoryFinalizerOnImageRepository(imageRepositoryKey types.Name
 }
 
 // remove after fully migrated to new group
-func waitImageRepositoryFinalizerOnImageRepository_old(imageRepositoryKey types.NamespacedName) {
+func waitImageRepositoryFinalizerOnImageRepositoryOldModel(imageRepositoryKey types.NamespacedName) {
 	imageRepository := &imagerepositoryv1alpha1.ImageRepository{}
 	Eventually(func() bool {
 		if err := k8sClient.Get(ctx, imageRepositoryKey, imageRepository); err != nil {
 			return false
 		}
-		return controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizer)
+		return controllerutil.ContainsFinalizer(imageRepository, ImageRepositoryFinalizerOldModel)
 	}, timeout, interval).Should(BeTrue())
 }
 
@@ -500,9 +528,9 @@ func waitImageRepositoryCredentialSectionRequestGone(imageRepositoryKey types.Na
 }
 
 // remove after fully migrated to new group
-func waitImageRepositoryCredentialSectionRequestGone_old(imageRepositoryKey types.NamespacedName, operationName string) {
+func waitImageRepositoryCredentialSectionRequestGoneOldModel(imageRepositoryKey types.NamespacedName, operationName string) {
 	Eventually(func() bool {
-		imageRepository := getImageRepository_old(imageRepositoryKey)
+		imageRepository := getImageRepositoryOldModel(imageRepositoryKey)
 		switch operationName {
 		case "regenerate":
 			if imageRepository.Spec.Credentials.RegenerateToken == nil {
@@ -663,6 +691,19 @@ func verifySecretSpec(secret *corev1.Secret, ownerKind, ownerAPIVersion, ownerNa
 		Expect(secret.OwnerReferences[0].Name).To(Equal(ownerName))
 	}
 	Expect(secret.Labels[InternalSecretLabelName]).To(Equal("true"))
+	Expect(secret.Name).To(Equal(secretName))
+	Expect(secret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+}
+
+// remove after fully migrated to new group
+func verifySecretSpecOldModel(secret *corev1.Secret, ownerKind, ownerAPIVersion, ownerName, secretName string) {
+	if ownerKind != "" && ownerAPIVersion != "" && ownerName != "" {
+		Expect(secret.OwnerReferences).To(HaveLen(1))
+		Expect(secret.OwnerReferences[0].Kind).To(Equal(ownerKind))
+		Expect(secret.OwnerReferences[0].APIVersion).To(Equal(ownerAPIVersion))
+		Expect(secret.OwnerReferences[0].Name).To(Equal(ownerName))
+	}
+	Expect(secret.Labels[InternalSecretLabelNameOldModel]).To(Equal("true"))
 	Expect(secret.Name).To(Equal(secretName))
 	Expect(secret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
 }


### PR DESCRIPTION
Extend ImageRepository controller to handle both appstudio.redhat.com/v1alpha1
and konflux-ci.dev/v1alpha1 Component types, and rename all appstudio-prefixed
labels, annotations and finalizers to konflux-ci.dev branding in the new model
code path.

Dual-Group Component Support:
- Bump application-api dependency to include konflux-ci.dev/v1alpha1 Component
- Component fetch and update selects the correct type based on r.IsOldGroup
- Covers all three interaction points: existence check before provisioning,
  spec.containerImage update after provision, and owner reference resolution
- isComponentLinked() accepts isOldGroup and checks the right label per group
- RBAC markers extended to include konflux-ci.dev Component group

Renamed Constants (appstudio → konflux, new model only):
- appstudio.openshift.io/image-repository → konflux-ci.dev/image-repository (ImageRepositoryFinalizer)
- appstudio.redhat.com/internal → konflux-ci.dev/internal (InternalSecretLabelName)
- appstudio.redhat.com/component → build.konflux-ci.dev/component (ComponentNameLabelName)
- image-controller.appstudio.redhat.com/skip-repository-deletion → build.konflux-ci.dev/skip-repository-deletion (skipRepositoryDeletionAnnotationName)
- image-controller.appstudio.redhat.com/update-component-image → build.konflux-ci.dev/update-component-image (updateComponentAnnotationName)
- image-controller.appstudio.redhat.com/namespace-pull-secret-ensured → build.konflux-ci.dev/namespace-pull-secret-ensured (namespacePullSecretEnsuredAnnotation)
- Each constant retains an OldModel-suffixed variant with the original value
- All callsites not already gated by r.IsOldGroup updated to dispatch to the correct variant
- Old-group code in application_controller.go and component_image_controller.go
  updated to use the OldModel constants

Test Updates:
- suite_util_test.go: add new-group Component helpers (getSampleComponentData,
  createComponent, getComponent) using compv1alpha1.Component
- Test helpers renamed from _old suffix to OldModel for consistency with production code
- Old-group tests updated to use OldModel constants throughout
- New unit tests: TestIsComponentLinkedOldModel, TestGetQuayImageNameAndURLOldModel

Documentation:
- README.md updated to document new annotation/label names alongside old ones

[STONEBLD-4824](https://redhat.atlassian.net/browse/STONEBLD-4824)

Signed-off-by: Robert Cerven <rcerven@redhat.com>

[STONEBLD-4824]: https://redhat.atlassian.net/browse/STONEBLD-4824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ