### PR TITLE
Fix .codecov.yml: ignore generated files and config manifests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,11 @@
 codecov:
   require_ci_to_pass: false
 
+ignore:
+  - "**/zz_generated*.go"  # generated deepcopy code
+  - "config/**"            # CRD, RBAC, and kustomize manifests
+  - "vendor/**"            # vendored dependencies
+
 coverage:
   status:
     project:
@@ -13,4 +18,6 @@ coverage:
         target: 80%
         informational: true
 
-comment: false
+comment:
+  layout: "reach,diff,flags,files,footer"
+  require_changes: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,6 +18,4 @@ coverage:
         target: 80%
         informational: true
 
-comment:
-  layout: "reach,diff,flags,files,footer"
-  require_changes: true
+comment: false


### PR DESCRIPTION
## Summary

- Add `ignore:` patterns for generated files (`zz_generated*.go`, `config/**`, `vendor/**`) that were dragging down patch coverage metrics
- Keeps existing coverage targets (80% patch, auto project) and informational mode
- Keeps `comment: false` per team preference

## Context

The Konflux Code Coverage Report flagged image-controller at **42.25% patch coverage** over the last 7 days. Investigation showed that generated deepcopy files (`zz_generated.deepcopy.go`, +257 lines) and CRD manifests were being counted as uncovered production code, significantly skewing the metric.

## Test plan

- [ ] Verify Codecov stops counting `zz_generated*.go` and `config/` files in patch coverage

Signed-off-by: Eyal Edri <eedri@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)